### PR TITLE
feat/LJJ(#8): 이메일 인증 모달추가, 에러핸들링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
         "jest": "^29.7.0",
-        "path": "^0.12.7",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.18.2",
         "vite": "^6.0.5",
@@ -8842,17 +8841,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -10605,29 +10593,12 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "2.0.3"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/util/node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@eslint/js": "^9.17.0",
         "@testing-library/react": "^16.1.0",
+        "@types/node": "^22.10.5",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react-swc": "^3.5.0",
@@ -30,6 +31,7 @@
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
         "jest": "^29.7.0",
+        "path": "^0.12.7",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.18.2",
         "vite": "^6.0.5",
@@ -2855,9 +2857,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8840,6 +8842,17 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -10592,12 +10605,29 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",
     "jest": "^29.7.0",
-    "path": "^0.12.7",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",
     "vite": "^6.0.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@testing-library/react": "^16.1.0",
+    "@types/node": "^22.10.5",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react-swc": "^3.5.0",
@@ -34,6 +35,7 @@
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",
     "jest": "^29.7.0",
+    "path": "^0.12.7",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",
     "vite": "^6.0.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,32 +1,23 @@
-import { useState } from 'react';
-import Modal from './components/Modal';
 import AppProvider from './provider/AppProvider';
 import { Route } from 'react-router-dom';
 import ThemeColorProvider from './provider/ThemeColorProvider';
 import Root from './components/Root';
 import Main from './components/Main';
+import ChangePassword from './components/Auth/ChangePassword';
 
 function App() {
-  const [totalOpen, setTotalOpen] = useState<boolean>(false);
-
   return (
     <>
       <ThemeColorProvider>
         <AppProvider>
-          <Route path="/root" element={<Root />}></Route>
-          <Route path="/honeyJar" element={<Main />}></Route>
+          <Route path="/root" element={<Root />} />
+          <Route path="/honeyJar" element={<Main />} />
+          <Route
+            path="/account/change-password/:token/:id"
+            element={<ChangePassword />}
+          />
         </AppProvider>
       </ThemeColorProvider>
-      <button onClick={() => setTotalOpen(!totalOpen)}>모달테스트</button>
-      <Modal isOpen={totalOpen}>
-        <div style={{ border: '1px solid red', backgroundColor: 'white' }}>
-          <h1>헤더</h1>
-          <div>
-            <h1>바디</h1>
-            <p>des</p>
-          </div>
-        </div>
-      </Modal>
     </>
   );
 }

--- a/src/apis/auth/endpoint.ts
+++ b/src/apis/auth/endpoint.ts
@@ -1,5 +1,7 @@
+import { EmailForChangePwType } from '@/components/Auth/type';
 import { BeforeAuthInstance } from '../axiosInstance';
 import {
+  ChangePasswordRequest,
   LoginRequest,
   LoginReturn,
   RegisterRequest,
@@ -28,5 +30,38 @@ export async function postUserRegister(
   registerInfo: RegisterRequest
 ): Promise<RegisterReturn> {
   const response = await BeforeAuthInstance.post('/users', registerInfo);
+  return response.data;
+}
+
+//비밀번호 변경을 위한 Email전송 api
+export async function postEmailForChangePw({
+  email,
+}: EmailForChangePwType): Promise<void> {
+  const response = await BeforeAuthInstance.post(
+    `/users/${email}/user-verify-tokens/password-change`,
+    {
+      connectUrl: `${import.meta.env.VITE_CHANGE_PW_URL}`,
+    }
+  );
+  return response.data;
+}
+
+//비밀번호 변경 api
+export async function putChangePassword({
+  id,
+  token,
+  newPassword,
+}: ChangePasswordRequest): Promise<void> {
+  const response = await BeforeAuthInstance.put(
+    `/users/${id}/password`,
+    {
+      newPassword,
+    },
+    {
+      params: {
+        token,
+      },
+    }
+  );
   return response.data;
 }

--- a/src/apis/auth/endpoint.ts
+++ b/src/apis/auth/endpoint.ts
@@ -14,7 +14,7 @@ export async function postToken(loginInfo: LoginRequest): Promise<LoginReturn> {
   const combined = `${loginInfo.email}:${loginInfo.password}`;
   const encodeCombined = btoa(combined);
   const response = await BeforeAuthInstance.post(
-    '/tokens',
+    '/auth/sign-in',
     {},
     {
       headers: {
@@ -29,7 +29,7 @@ export async function postToken(loginInfo: LoginRequest): Promise<LoginReturn> {
 export async function postUserRegister(
   registerInfo: RegisterRequest
 ): Promise<RegisterReturn> {
-  const response = await BeforeAuthInstance.post('/users', registerInfo);
+  const response = await BeforeAuthInstance.post('/auth/sign-up', registerInfo);
   return response.data;
 }
 

--- a/src/apis/auth/error.ts
+++ b/src/apis/auth/error.ts
@@ -17,3 +17,25 @@ export function RegisterErrorHandler(error: AxiosError) {
   if (code === 1) return '형식을 다시 확인해 주세요.';
   if (code === 1000) return '이미 존재하는 이메일 입니다.';
 }
+
+export function SendEmailForChangePwErrorHandler(error: AxiosError) {
+  const responseData = error.response?.data as ErrorResponse;
+  const code = responseData?.code;
+  if (code === 0) return '서버 오류 입니다. 잠시 후 다시 시도해주세요.';
+  if (code === 1) return '형식을 맞게 입력해 주세요.';
+  if (code === 5) return '존재하지 않는 이메일 입니다.';
+  if (code === 1005)
+    return '비밀번호 변경 재전송은 최초 전송 후 1시간 이후에 가능합니다.';
+}
+
+export function ChangePasswordErrorHandler(error: AxiosError) {
+  const responseData = error.response?.data as ErrorResponse;
+  const code = responseData?.code;
+  if (code === 0) return '서버 오류 입니다. 잠시 후 다시 시도해주세요.';
+  if (code === 1) return '형식이 잘못되었습니다.';
+  if (code === 1006) return '토큰이 유효하지 않습니다.';
+  if (code === 4) return '비정상적인 접근입니다.';
+  if (code === 5) return '리소스를 찾을 수 없습니다.';
+  if (code === 1007)
+    return '이미 사용된 접근입니다. 처음부터 다시 시도해 주세요.';
+}

--- a/src/apis/auth/error.ts
+++ b/src/apis/auth/error.ts
@@ -1,0 +1,19 @@
+import { AxiosError } from 'axios';
+import { ErrorResponse } from './type';
+
+export function LoginErrorHandler(error: AxiosError) {
+  const responseData = error.response?.data as ErrorResponse;
+  const code = responseData?.code;
+  if (code === 0) return '서버 오류 입니다. 잠시 후 다시 시도해주세요.';
+  if (code === 1) return '아이디 혹은 비밀번호를 확인해 주세요.';
+  if (code === 3) return '유효하지 않은 토큰입니다. 다시 시도해주세요.';
+  if (code === 2000) return '아이디 혹은 비밀번호를 확인해 주세요.';
+}
+
+export function RegisterErrorHandler(error: AxiosError) {
+  const responseData = error.response?.data as ErrorResponse;
+  const code = responseData?.code;
+  if (code === 0) return '서버 오류 입니다. 잠시 후 다시 시도해주세요.';
+  if (code === 1) return '형식을 다시 확인해 주세요.';
+  if (code === 1000) return '이미 존재하는 이메일 입니다.';
+}

--- a/src/apis/auth/queries.ts
+++ b/src/apis/auth/queries.ts
@@ -1,34 +1,37 @@
-import { useMutation } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { LoginRequest, RegisterRequest } from './type';
 import { AuthEndPoint } from '.';
+import { AxiosError } from 'axios';
+import { LoginErrorHandler, RegisterErrorHandler } from './error';
 
 export const LoginQuery = () => {
-  const navigate = useNavigate();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (loginInfo: LoginRequest) => AuthEndPoint.postToken(loginInfo),
     onSuccess: data => {
-      console.log('로그인 성공:', data);
-      navigate('/honeyJar');
+      queryClient.invalidateQueries({
+        queryKey: ['tokens'],
+      });
+      localStorage.setItem('accessToken', data.accessToken);
     },
-    onError: (error: unknown) => {
-      console.error('로그인 실패:', error);
-      alert('로그인 실패 아이디 비번을 확인');
+    onError: (error: AxiosError) => {
+      alert(LoginErrorHandler(error));
     },
   });
 };
 
 export const RegisterQuery = () => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (registerInfo: RegisterRequest) =>
       AuthEndPoint.postUserRegister(registerInfo),
-    onSuccess: data => {
-      console.log('회원가입 성공:', data);
-      alert('회원가입 성공!');
+    onSuccess: () => {
+      return queryClient.invalidateQueries({
+        queryKey: ['users'],
+      });
     },
-    onError: (error: unknown) => {
-      console.error('회원가입 실패:', error);
-      alert('회원가입 실패. 다시 시도해주세요.');
+    onError: (error: AxiosError) => {
+      alert(RegisterErrorHandler(error));
     },
   });
 };

--- a/src/apis/auth/queries.ts
+++ b/src/apis/auth/queries.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { ChangePasswordRequest, LoginRequest, RegisterRequest } from './type';
 import { AuthEndPoint } from '.';
 import { AxiosError } from 'axios';
 import {
@@ -8,13 +7,12 @@ import {
   RegisterErrorHandler,
   SendEmailForChangePwErrorHandler,
 } from './error';
-import { EmailForChangePwType } from '@/components/Auth/type';
 
 /** 로그인 쿼리 */
 export const LoginQuery = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (loginInfo: LoginRequest) => AuthEndPoint.postToken(loginInfo),
+    mutationFn: AuthEndPoint.postToken,
     onSuccess: data => {
       queryClient.invalidateQueries({
         queryKey: ['tokens'],
@@ -31,8 +29,7 @@ export const LoginQuery = () => {
 export const RegisterQuery = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (registerInfo: RegisterRequest) =>
-      AuthEndPoint.postUserRegister(registerInfo),
+    mutationFn: AuthEndPoint.postUserRegister,
     onSuccess: () => {
       return queryClient.invalidateQueries({
         queryKey: ['users'],
@@ -48,8 +45,7 @@ export const RegisterQuery = () => {
 export const SendEmailForChangePwQuery = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ email }: EmailForChangePwType) =>
-      AuthEndPoint.postEmailForChangePw({ email }),
+    mutationFn: AuthEndPoint.postEmailForChangePw,
     onSuccess: () => {
       return queryClient.invalidateQueries({
         queryKey: ['users', 'user-verify-tokens', 'password-change'],
@@ -65,8 +61,7 @@ export const SendEmailForChangePwQuery = () => {
 export const ChangePasswordQuery = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, token, newPassword }: ChangePasswordRequest) =>
-      AuthEndPoint.putChangePassword({ id, token, newPassword }),
+    mutationFn: AuthEndPoint.putChangePassword,
     onSuccess: () => {
       return queryClient.invalidateQueries({
         queryKey: ['users', 'password'],

--- a/src/apis/auth/queries.ts
+++ b/src/apis/auth/queries.ts
@@ -1,9 +1,16 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { LoginRequest, RegisterRequest } from './type';
+import { ChangePasswordRequest, LoginRequest, RegisterRequest } from './type';
 import { AuthEndPoint } from '.';
 import { AxiosError } from 'axios';
-import { LoginErrorHandler, RegisterErrorHandler } from './error';
+import {
+  ChangePasswordErrorHandler,
+  LoginErrorHandler,
+  RegisterErrorHandler,
+  SendEmailForChangePwErrorHandler,
+} from './error';
+import { EmailForChangePwType } from '@/components/Auth/type';
 
+/** 로그인 쿼리 */
 export const LoginQuery = () => {
   const queryClient = useQueryClient();
   return useMutation({
@@ -20,6 +27,7 @@ export const LoginQuery = () => {
   });
 };
 
+/** 회원가입 쿼리 */
 export const RegisterQuery = () => {
   const queryClient = useQueryClient();
   return useMutation({
@@ -32,6 +40,40 @@ export const RegisterQuery = () => {
     },
     onError: (error: AxiosError) => {
       alert(RegisterErrorHandler(error));
+    },
+  });
+};
+
+/**비밀번호 변경을 위한 이메일 인증 쿼리 */
+export const SendEmailForChangePwQuery = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ email }: EmailForChangePwType) =>
+      AuthEndPoint.postEmailForChangePw({ email }),
+    onSuccess: () => {
+      return queryClient.invalidateQueries({
+        queryKey: ['users', 'user-verify-tokens', 'password-change'],
+      });
+    },
+    onError(error: AxiosError) {
+      alert(SendEmailForChangePwErrorHandler(error));
+    },
+  });
+};
+
+/**비밀번호 변경을 위한 쿼리 */
+export const ChangePasswordQuery = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, token, newPassword }: ChangePasswordRequest) =>
+      AuthEndPoint.putChangePassword({ id, token, newPassword }),
+    onSuccess: () => {
+      return queryClient.invalidateQueries({
+        queryKey: ['users', 'password'],
+      });
+    },
+    onError(error: AxiosError) {
+      alert(ChangePasswordErrorHandler(error));
     },
   });
 };

--- a/src/apis/auth/type.d.ts
+++ b/src/apis/auth/type.d.ts
@@ -17,3 +17,7 @@ export interface LoginRequest {
 export interface LoginReturn {
   accessToken: string;
 }
+
+interface ErrorResponse {
+  code: number;
+}

--- a/src/apis/auth/type.d.ts
+++ b/src/apis/auth/type.d.ts
@@ -18,6 +18,12 @@ export interface LoginReturn {
   accessToken: string;
 }
 
-interface ErrorResponse {
+export interface ErrorResponse {
   code: number;
+}
+
+export interface ChangePasswordRequest {
+  id: string;
+  token: string;
+  newPassword: string;
 }

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -5,7 +5,7 @@ export const BeforeAuthInstance = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  timeout: 3000,
+  timeout: 5000,
 });
 
 // 요청 인터셉터 추가하기

--- a/src/components/Auth/ChangePassword.tsx
+++ b/src/components/Auth/ChangePassword.tsx
@@ -1,0 +1,92 @@
+import * as S from './changePwStyle';
+import { Header } from '../Layouts';
+import { Svg } from '../Svg';
+import { useState } from 'react';
+import { onChangeTextInfo } from './utils';
+import { useNavigate, useParams } from 'react-router-dom';
+import { AuthQueries } from '@/apis/auth';
+import { Loading } from '..';
+
+interface ChangeInfo {
+  password: string;
+  checkPassword: string;
+}
+
+/**해당 컴포넌트는 후에 account폴더로 이동 예정 */
+export default function ChangePassword() {
+  const [changeInfo, setChangeInfo] = useState<ChangeInfo>({
+    password: '',
+    checkPassword: '',
+  });
+  const params = useParams();
+  const navigate = useNavigate();
+
+  const onChangeNewPasswordInfo = onChangeTextInfo({ setState: setChangeInfo });
+  const mutationChangePassword = AuthQueries.ChangePasswordQuery();
+
+  const onSubmitChangePassword: React.FormEventHandler<HTMLFormElement> = e => {
+    e.preventDefault();
+    if (changeInfo.password !== changeInfo.checkPassword) {
+      alert('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+    mutationChangePassword.mutate(
+      {
+        newPassword: changeInfo.password,
+        token: params.token as string,
+        id: params.id as string,
+      },
+      {
+        onSuccess: () => navigate('/root'),
+      }
+    );
+  };
+
+  return (
+    <>
+      <Header.SettingHeader titleText="비밀번호 변경" redirect="/root" />
+      <S.ChangePasswordWrapper>
+        <S.ChangePasswordContainer>
+          <S.KeyIconContainer>
+            <Svg.KeyIcon size={35} />
+          </S.KeyIconContainer>
+          <S.NotificationChangePasswordValidationP>
+            비밀번호는 영문(대/소), 숫자, 특수문자(@$!%*?&)를 포함한 8자리 이상
+            15자리 이하의 비밀번호를 입력해 주세요.
+          </S.NotificationChangePasswordValidationP>
+          <S.ChangePasswordForm onSubmit={onSubmitChangePassword}>
+            <S.ChangePasswordInputBox>
+              <div style={{ display: 'flex' }}>
+                <label>새 비밀번호</label>
+              </div>
+              <input
+                type="password"
+                id="password"
+                value={changeInfo.password}
+                onChange={onChangeNewPasswordInfo}
+              />
+            </S.ChangePasswordInputBox>
+            <S.ChangePasswordInputBox>
+              <label>새 비밀번호 확인</label>
+              <input
+                type="password"
+                id="checkPassword"
+                value={changeInfo.checkPassword}
+                onChange={onChangeNewPasswordInfo}
+              />
+            </S.ChangePasswordInputBox>
+            <S.ChangePasswordSubmitButtonContainer>
+              <button>
+                {mutationChangePassword.isPending ? (
+                  <Loading.Spinner />
+                ) : (
+                  <>비밀번호 변경</>
+                )}
+              </button>
+            </S.ChangePasswordSubmitButtonContainer>
+          </S.ChangePasswordForm>
+        </S.ChangePasswordContainer>
+      </S.ChangePasswordWrapper>
+    </>
+  );
+}

--- a/src/components/Auth/ChangePassword.tsx
+++ b/src/components/Auth/ChangePassword.tsx
@@ -37,7 +37,10 @@ export default function ChangePassword() {
         id: params.id as string,
       },
       {
-        onSuccess: () => navigate('/root'),
+        onSuccess: () => {
+          alert('비밀번호가 성공적으로 변경되었습니다.');
+          navigate('/root');
+        },
       }
     );
   };

--- a/src/components/Auth/LoginModal.tsx
+++ b/src/components/Auth/LoginModal.tsx
@@ -2,7 +2,7 @@ import * as S from './style';
 import Image from '../Image';
 import { LoginInfo, ModalProps } from './type';
 import { useState } from 'react';
-import { AuthQueries } from '@apis/auth';
+import { AuthQueries } from '@/apis/auth';
 import { onChangeTextInfo, toggleCheckBox } from './utils';
 import { useNavigate } from 'react-router-dom';
 import { Loading } from '..';

--- a/src/components/Auth/LoginModal.tsx
+++ b/src/components/Auth/LoginModal.tsx
@@ -2,7 +2,7 @@ import * as S from './style';
 import Image from '../Image';
 import { LoginInfo, ModalProps } from './type';
 import { useState } from 'react';
-import { AuthQueries } from '../../apis/auth';
+import { AuthQueries } from '@apis/auth';
 import { onChangeTextInfo, toggleCheckBox } from './utils';
 import { useNavigate } from 'react-router-dom';
 import { Loading } from '..';

--- a/src/components/Auth/LoginModal.tsx
+++ b/src/components/Auth/LoginModal.tsx
@@ -89,7 +89,12 @@ export default function LoginModal({ setStep }: ModalProps) {
             />
             <label>로그인 상태 유지</label>
           </div>
-          <S.LinkedInButton>비밀번호 찾기</S.LinkedInButton>
+          <S.LinkedInButton
+            type="button"
+            onClick={() => setStep('비밀번호 찾기')}
+          >
+            비밀번호 찾기
+          </S.LinkedInButton>
         </S.LoginBottom>
         <S.SubmitButton type="submit">
           {mutation.isPending ? <Loading.Spinner /> : <>로그인</>}

--- a/src/components/Auth/LoginModal.tsx
+++ b/src/components/Auth/LoginModal.tsx
@@ -4,6 +4,8 @@ import { LoginInfo, ModalProps } from './type';
 import { useState } from 'react';
 import { AuthQueries } from '../../apis/auth';
 import { onChangeTextInfo, toggleCheckBox } from './utils';
+import { useNavigate } from 'react-router-dom';
+import { Loading } from '..';
 
 export default function LoginModal({ setStep }: ModalProps) {
   const [loginInfo, setLoginInfo] = useState<LoginInfo>({
@@ -11,6 +13,8 @@ export default function LoginModal({ setStep }: ModalProps) {
     password: '',
     isAutoLogin: false,
   });
+
+  const navigate = useNavigate();
 
   //로그인 정보 변경 핸들러
   const onChangeLoginInfo = onChangeTextInfo<LoginInfo>({
@@ -37,7 +41,10 @@ export default function LoginModal({ setStep }: ModalProps) {
     e.preventDefault();
     const { email, password } = loginInfo;
     if (validationInfo()) {
-      mutation.mutate({ email, password });
+      mutation.mutate(
+        { email, password },
+        { onSuccess: () => navigate('/honeyJar') }
+      );
     }
   };
 
@@ -84,7 +91,9 @@ export default function LoginModal({ setStep }: ModalProps) {
           </div>
           <S.LinkedInButton>비밀번호 찾기</S.LinkedInButton>
         </S.LoginBottom>
-        <S.SubmitButton type="submit">로그인</S.SubmitButton>
+        <S.SubmitButton type="submit">
+          {mutation.isPending ? <Loading.Spinner /> : <>로그인</>}
+        </S.SubmitButton>
       </S.AuthForm>
       <S.ModalBottom>
         <span>계정이 없으신가요?</span>

--- a/src/components/Auth/RegisterModal.tsx
+++ b/src/components/Auth/RegisterModal.tsx
@@ -10,7 +10,7 @@ import {
   validationRegisterInfo,
 } from './utils';
 import { useStore } from 'zustand';
-import { useUserInfoStore } from '@store/authStore/userInfoStore';
+import { useUserInfoStore } from '@/store/authStore/userInfoStore';
 import { Loading } from '..';
 
 export default function RegisterModal({ setStep }: ModalProps) {

--- a/src/components/Auth/RegisterModal.tsx
+++ b/src/components/Auth/RegisterModal.tsx
@@ -3,14 +3,14 @@ import Image from '../Image';
 import { ModalProps, RegisterInfo } from './type';
 import { useEffect, useState } from 'react';
 import { Svg } from '../Svg';
-import { AuthQueries } from '../../apis/auth';
+import { AuthQueries } from '@/apis/auth';
 import {
   onChangeTextInfo,
   toggleCheckBox,
   validationRegisterInfo,
 } from './utils';
 import { useStore } from 'zustand';
-import { useUserInfoStore } from '../../store/authStore/userInfoStore';
+import { useUserInfoStore } from '@store/authStore/userInfoStore';
 import { Loading } from '..';
 
 export default function RegisterModal({ setStep }: ModalProps) {

--- a/src/components/Auth/RegisterModal.tsx
+++ b/src/components/Auth/RegisterModal.tsx
@@ -1,7 +1,7 @@
 import * as S from './style';
 import Image from '../Image';
 import { ModalProps, RegisterInfo } from './type';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Svg } from '../Svg';
 import { AuthQueries } from '../../apis/auth';
 import {
@@ -9,6 +9,9 @@ import {
   toggleCheckBox,
   validationRegisterInfo,
 } from './utils';
+import { useStore } from 'zustand';
+import { useUserInfoStore } from '../../store/authStore/userInfoStore';
+import { Loading } from '..';
 
 export default function RegisterModal({ setStep }: ModalProps) {
   const [registerInfo, setRegisterInfo] = useState<RegisterInfo>({
@@ -19,6 +22,8 @@ export default function RegisterModal({ setStep }: ModalProps) {
     conditions: false,
   });
 
+  const userInfo = useStore(useUserInfoStore);
+
   const onChangeRegisterInfo = onChangeTextInfo<RegisterInfo>({
     setState: setRegisterInfo,
   });
@@ -28,7 +33,8 @@ export default function RegisterModal({ setStep }: ModalProps) {
     key: 'conditions',
   });
 
-  const mutation = AuthQueries.RegisterQuery();
+  const mutationRegister = AuthQueries.RegisterQuery();
+  const mutationLogin = AuthQueries.LoginQuery();
 
   const onSubmitRegister: React.FormEventHandler<HTMLFormElement> = e => {
     e.preventDefault();
@@ -36,9 +42,21 @@ export default function RegisterModal({ setStep }: ModalProps) {
     const isValid = validationRegisterInfo(registerInfo);
     if (isValid.result) {
       //api호출
-      mutation.mutate({ email, password, nickname , mbti: null});
+      mutationRegister.mutate(
+        { email, password, nickname, mbti: null },
+        {
+          onSuccess: () => {
+            setStep('이메일 인증');
+            mutationLogin.mutate({ email, password });
+          },
+        }
+      );
     }
   };
+
+  useEffect(() => {
+    userInfo.setEmail(registerInfo.email);
+  }, [registerInfo.email]);
 
   return (
     <>
@@ -111,7 +129,9 @@ export default function RegisterModal({ setStep }: ModalProps) {
               <label>이용약관과 개인정보처리방침에 동의합니다.</label>
             </div>
           </S.LoginBottom>
-          <S.SubmitButton type="submit">회원가입</S.SubmitButton>
+          <S.SubmitButton type="submit">
+            {mutationRegister.isPending ? <Loading.Spinner /> : <>회원가입</>}
+          </S.SubmitButton>
         </S.AuthForm>
         <S.ModalBottom>
           <span>이미 계정이 있으신가요?</span>

--- a/src/components/Auth/SendEmailForChnagePasswordModal.tsx
+++ b/src/components/Auth/SendEmailForChnagePasswordModal.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { Svg } from '../Svg';
+import * as S from './style';
+import { onChangeTextInfo } from './utils';
+import { EmailForChangePwType, ModalProps } from './type';
+import { AuthQueries } from '@/apis/auth';
+
+export default function SendEmailForChangePasswordModal({
+  setStep,
+}: ModalProps) {
+  const [forChangePw, setForChangePw] = useState<EmailForChangePwType>({
+    email: '',
+  });
+
+  const mutationSendEmail = AuthQueries.SendEmailForChangePwQuery();
+
+  const onChangeEmailForChangePw = onChangeTextInfo<EmailForChangePwType>({
+    setState: setForChangePw,
+  });
+  const onSubmitEmailForChangePw: React.FormEventHandler<
+    HTMLFormElement
+  > = e => {
+    e.preventDefault();
+    if (forChangePw.email) {
+      mutationSendEmail.mutate(
+        {
+          email: forChangePw.email,
+        },
+        { onSuccess: () => alert('이메일을 확인해주세요.') }
+      );
+    }
+  };
+
+  return (
+    <S.ModalWrapper>
+      <S.ChangePasswordHeader>
+        <S.KeyIconContainer>
+          <Svg.KeyIcon size={24} />
+        </S.KeyIconContainer>
+        <h3>비밀번호 찾기</h3>
+        <S.SendToEmailP>
+          가입하신 이메일 주소를 입력해 주세요. 비밀번호 재설정 링크를
+          보내드립니다.
+        </S.SendToEmailP>
+      </S.ChangePasswordHeader>
+      <form onSubmit={onSubmitEmailForChangePw}>
+        <S.EmailInputForChangePasswordContainer>
+          <label>이메일 주소</label>
+          <input
+            type="email"
+            id="email"
+            required
+            value={forChangePw.email}
+            onChange={onChangeEmailForChangePw}
+          />
+        </S.EmailInputForChangePasswordContainer>
+        <S.SendEmailBottom>
+          <button type="submit">비밀번호 변경 이메일 받기</button>
+          <button type="button" onClick={() => setStep('로그인')}>
+            취소
+          </button>
+        </S.SendEmailBottom>
+      </form>
+    </S.ModalWrapper>
+  );
+}

--- a/src/components/Auth/SendEmailForChnagePasswordModal.tsx
+++ b/src/components/Auth/SendEmailForChnagePasswordModal.tsx
@@ -4,6 +4,7 @@ import * as S from './style';
 import { onChangeTextInfo } from './utils';
 import { EmailForChangePwType, ModalProps } from './type';
 import { AuthQueries } from '@/apis/auth';
+import { Loading } from '..';
 
 export default function SendEmailForChangePasswordModal({
   setStep,
@@ -26,7 +27,12 @@ export default function SendEmailForChangePasswordModal({
         {
           email: forChangePw.email,
         },
-        { onSuccess: () => alert('이메일을 확인해주세요.') }
+        {
+          onSuccess: () =>
+            alert(
+              `${forChangePw.email}해당 이메일로 메일을 보내드렸습니다.\n만약 메일이 오지 않았다면 스팸함을 확인해 주세요😊`
+            ),
+        }
       );
     }
   };
@@ -55,7 +61,13 @@ export default function SendEmailForChangePasswordModal({
           />
         </S.EmailInputForChangePasswordContainer>
         <S.SendEmailBottom>
-          <button type="submit">비밀번호 변경 이메일 받기</button>
+          <button type="submit">
+            {mutationSendEmail.isPending ? (
+              <Loading.Spinner />
+            ) : (
+              <>비밀번호 변경 이메일 받기</>
+            )}
+          </button>
           <button type="button" onClick={() => setStep('로그인')}>
             취소
           </button>

--- a/src/components/Auth/VerificationEmailModal.tsx
+++ b/src/components/Auth/VerificationEmailModal.tsx
@@ -1,0 +1,37 @@
+import { useStore } from 'zustand';
+import { Svg } from '../Svg';
+import * as S from './style';
+import { useUserInfoStore } from '../../store/authStore/userInfoStore';
+import { useNavigate } from 'react-router-dom';
+
+export default function VerificationEmailModal() {
+  const userInfo = useStore(useUserInfoStore);
+  const navigate = useNavigate();
+  return (
+    <>
+      <S.ModalWrapper>
+        <S.EmailAuthHeader>
+          <S.EmailIconContainer>
+            <Svg.EmailIcon size={24} />
+          </S.EmailIconContainer>
+          <h3>이메일 인증</h3>
+          <S.SendToEmailP>
+            <span>{userInfo.email}</span>로<br />
+            인증 메일을 발송했습니다.
+          </S.SendToEmailP>
+        </S.EmailAuthHeader>
+        <S.ExtraInfoDiv>
+          <Svg.InfoIcon size={24} />
+          <p>
+            이메일 인증을 완료하지 않으면 커플 연결 기능을 사용할 수 없습니다.
+          </p>
+        </S.ExtraInfoDiv>
+        <S.EmailAuthBottom>
+          <button onClick={() => navigate('/honeyJar')}>확인했습니다</button>
+          <button>이메일 재전송</button>
+          <p>프로필 설정에서 언제든지 이메일 인증을 진행할 수 있습니다.</p>
+        </S.EmailAuthBottom>
+      </S.ModalWrapper>
+    </>
+  );
+}

--- a/src/components/Auth/VerificationEmailModal.tsx
+++ b/src/components/Auth/VerificationEmailModal.tsx
@@ -27,6 +27,7 @@ export default function VerificationEmailModal() {
           </p>
         </S.ExtraInfoDiv>
         <S.EmailAuthBottom>
+          <p>이메일이 보이지 않는경우 스팸함을 확인해 보세요.</p>
           <button onClick={() => navigate('/honeyJar')}>확인했습니다</button>
           <button>이메일 재전송</button>
           <p>프로필 설정에서 언제든지 이메일 인증을 진행할 수 있습니다.</p>

--- a/src/components/Auth/VerificationEmailModal.tsx
+++ b/src/components/Auth/VerificationEmailModal.tsx
@@ -1,7 +1,7 @@
 import { useStore } from 'zustand';
 import { Svg } from '../Svg';
 import * as S from './style';
-import { useUserInfoStore } from '@store/authStore/userInfoStore';
+import { useUserInfoStore } from '@/store/authStore/userInfoStore';
 import { useNavigate } from 'react-router-dom';
 
 export default function VerificationEmailModal() {

--- a/src/components/Auth/VerificationEmailModal.tsx
+++ b/src/components/Auth/VerificationEmailModal.tsx
@@ -1,7 +1,7 @@
 import { useStore } from 'zustand';
 import { Svg } from '../Svg';
 import * as S from './style';
-import { useUserInfoStore } from '../../store/authStore/userInfoStore';
+import { useUserInfoStore } from '@store/authStore/userInfoStore';
 import { useNavigate } from 'react-router-dom';
 
 export default function VerificationEmailModal() {

--- a/src/components/Auth/changePwStyle.ts
+++ b/src/components/Auth/changePwStyle.ts
@@ -1,0 +1,85 @@
+import styled from 'styled-components';
+
+export const ChangePasswordWrapper = styled.div`
+  margin-top: 50px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const ChangePasswordContainer = styled.div`
+  width: 40%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const KeyIconContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 65px;
+  height: 65px;
+  border-radius: 50%;
+  background-color: ${({ theme }) => theme.button.primary.base};
+  > svg {
+    stroke: ${({ theme }) => theme.text.quaternary};
+  }
+`;
+
+export const NotificationChangePasswordValidationP = styled.p`
+  font-size: 16px;
+  width: 45%;
+  margin-top: 20px;
+  text-align: center;
+  color: ${({ theme }) => theme.accent};
+`;
+
+export const ChangePasswordForm = styled.form`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: start;
+`;
+
+export const ChangePasswordInputBox = styled.div`
+  width: 100%;
+  margin-top: 26px;
+  label {
+    font-size: 20px;
+  }
+  input {
+    width: 100%;
+    height: 50px;
+    margin-top: 10px;
+    padding: 0 10px;
+    border-radius: 10px;
+    border: 1px solid ${({ theme }) => theme.text.quaternary};
+    font-size: 16px;
+    outline: none;
+  }
+`;
+
+export const ChangePasswordSubmitButtonContainer = styled.div`
+  margin-top: 30px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  > button {
+    width: 100%;
+    height: 50px;
+    border-radius: 10px;
+    background-color: ${({ theme }) => theme.button.primary.base};
+    color: ${({ theme }) => theme.text.secondary};
+    font-size: 20px;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    &:hover {
+      background-color: ${({ theme }) => theme.button.primary.hover};
+    }
+  }
+`;

--- a/src/components/Auth/index.tsx
+++ b/src/components/Auth/index.tsx
@@ -4,11 +4,12 @@ import LoginModal from './LoginModal';
 import RegisterModal from './RegisterModal';
 import Modal from '../Modal';
 import useFunnel from '../../hook/useFunnel';
-import { SelectModalButton } from './type';
+import { AuthFunnelStep, SelectModalButton } from './type';
+import VerificationEmailModal from './VerificationEmailModal';
 
 export default function Auth() {
   const [authOpen, setAuthOpen] = useState<boolean>(false);
-  const { Funnel, setStep } = useFunnel<'로그인' | '회원가입'>('로그인');
+  const { Funnel, setStep } = useFunnel<AuthFunnelStep>('로그인');
 
   const onClickModalButton = ({ location }: SelectModalButton) => {
     if (location === '로그인') setStep('로그인');
@@ -33,6 +34,12 @@ export default function Auth() {
           </Funnel.Step>
           <Funnel.Step name="회원가입">
             <RegisterModal setStep={setStep} />
+          </Funnel.Step>
+          <Funnel.Step name="비밀번호 찾기">
+            <div>비밀번호 찾기</div>
+          </Funnel.Step>
+          <Funnel.Step name="이메일 인증">
+            <VerificationEmailModal />
           </Funnel.Step>
         </Funnel>
       </Modal>

--- a/src/components/Auth/index.tsx
+++ b/src/components/Auth/index.tsx
@@ -6,6 +6,7 @@ import Modal from '../Modal';
 import useFunnel from '../../hook/useFunnel';
 import { AuthFunnelStep, SelectModalButton } from './type';
 import VerificationEmailModal from './VerificationEmailModal';
+import SendEmailForChangePasswordModal from './SendEmailForChnagePasswordModal';
 
 export default function Auth() {
   const [authOpen, setAuthOpen] = useState<boolean>(false);
@@ -36,7 +37,7 @@ export default function Auth() {
             <RegisterModal setStep={setStep} />
           </Funnel.Step>
           <Funnel.Step name="비밀번호 찾기">
-            <div>비밀번호 찾기</div>
+            <SendEmailForChangePasswordModal setStep={setStep} />
           </Funnel.Step>
           <Funnel.Step name="이메일 인증">
             <VerificationEmailModal />

--- a/src/components/Auth/style.ts
+++ b/src/components/Auth/style.ts
@@ -188,3 +188,74 @@ export const EmailAuthBottom = styled.div`
     margin-top: 12px;
   }
 `;
+
+export const ChangePasswordHeader = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+`;
+
+export const KeyIconContainer = styled.div`
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background-color: ${({ theme }) => theme.bg.secondary};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  > svg {
+    stroke: ${({ theme }) => theme.button.primary.base};
+  }
+`;
+
+export const EmailInputForChangePasswordContainer = styled.div`
+  width: 100%;
+  margin-top: 16px;
+  label {
+    font-size: 12px;
+    color: ${({ theme }) => theme.text.primary};
+  }
+  input {
+    margin-top: 5px;
+    width: 100%;
+    border: 1px solid ${({ theme }) => theme.border.primary};
+    border-radius: 5px;
+    outline: none;
+    padding: 8px 0px 8px 5px;
+  }
+`;
+
+export const SendEmailBottom = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 16px;
+  gap: 8px;
+  button:nth-child(1) {
+    width: 100%;
+    height: 35px;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    color: ${({ theme }) => theme.text.secondary};
+    background-color: ${({ theme }) => theme.button.primary.base};
+    &:hover {
+      background-color: ${({ theme }) => theme.button.primary.hover};
+    }
+  }
+  button:nth-child(2) {
+    width: 100%;
+    height: 35px;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    color: ${({ theme }) => theme.text.primary};
+    background-color: ${({ theme }) => theme.button.tertiary};
+    &:hover {
+      background-color: ${({ theme }) => theme.button.tertiary.hover};
+    }
+  }
+`;

--- a/src/components/Auth/style.ts
+++ b/src/components/Auth/style.ts
@@ -113,3 +113,78 @@ export const ModalBottom = styled.div`
     color: ${({ theme }) => theme.text.tertiary};
   }
 `;
+
+export const EmailAuthHeader = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+`;
+
+export const EmailIconContainer = styled.div`
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background-color: ${({ theme }) => theme.bg.secondary};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  > svg {
+    stroke: ${({ theme }) => theme.button.primary.base};
+  }
+`;
+
+export const SendToEmailP = styled.p`
+  font-size: 16px;
+  span {
+    font-weight: 700;
+  }
+  text-align: center;
+`;
+
+export const ExtraInfoDiv = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  padding: 16px;
+  gap: 8px;
+  background-color: ${({ theme }) => theme.bg.secondary};
+  border-radius: 8px;
+  margin-top: 16px;
+  svg {
+    stroke: ${({ theme }) => theme.button.primary.base};
+  }
+  p {
+    font-size: 12px;
+    color: ${({ theme }) => theme.text.quaternary};
+  }
+`;
+
+export const EmailAuthBottom = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 16px;
+  button {
+    margin-top: 8px;
+    width: 100%;
+    height: 35px;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    color: ${({ theme }) => theme.text.secondary};
+    background-color: ${({ theme }) => theme.button.primary.base};
+    &:hover {
+      background-color: ${({ theme }) => theme.button.primary.hover};
+    }
+  }
+  p {
+    width: 70%;
+    font-size: 12px;
+    color: ${({ theme }) => theme.text.tertiary};
+    text-align: center;
+    margin-top: 12px;
+  }
+`;

--- a/src/components/Auth/type.d.ts
+++ b/src/components/Auth/type.d.ts
@@ -28,3 +28,7 @@ export type LoginInfo = {
   password: string;
   isAutoLogin: boolean;
 };
+
+export type EmailForChangePwType = {
+  email: string;
+};

--- a/src/components/Auth/type.d.ts
+++ b/src/components/Auth/type.d.ts
@@ -1,11 +1,17 @@
-//보달 버튼 클릭 시 함수
+export type AuthFunnelStep =
+  | '로그인'
+  | '회원가입'
+  | '비밀번호 찾기'
+  | '이메일 인증';
+
+//모달 버튼 클릭 시 함수
 export interface SelectModalButton {
-  location: '로그인' | '회원가입';
+  location: AuthFunnelStep;
 }
 
 //모달 Props
 export interface ModalProps {
-  setStep: (step: '로그인' | '회원가입') => void;
+  setStep: (step: AuthFunnelStep) => void;
 }
 
 //회원가입 status

--- a/src/components/Layouts/Header/SettingHeader.tsx
+++ b/src/components/Layouts/Header/SettingHeader.tsx
@@ -1,0 +1,28 @@
+import { useNavigate } from 'react-router-dom';
+import { Svg } from '../../Svg';
+import * as S from './style';
+import { SettingHeaderProps } from './type';
+
+/**
+ * SettingHeader 컴포넌트
+ *
+ * @param titleText Header에 들어갈 페이지 이름
+ * @returns Header 컴포넌트
+ */
+export default function SettingHeader({
+  titleText,
+  redirect,
+}: SettingHeaderProps) {
+  const navigate = useNavigate();
+
+  return (
+    <S.HeaderWrapper>
+      <S.SettingHeaderContents>
+        <S.PrevIconContainer onClick={() => navigate(redirect)}>
+          <Svg.PrevIcon />
+        </S.PrevIconContainer>
+        <h1>{titleText}</h1>
+      </S.SettingHeaderContents>
+    </S.HeaderWrapper>
+  );
+}

--- a/src/components/Layouts/Header/index.ts
+++ b/src/components/Layouts/Header/index.ts
@@ -1,2 +1,3 @@
 export { default as RootHeader } from './RootHeader';
 export { default as MainHeader } from './MainHeader';
+export { default as SettingHeader } from './SettingHeader';

--- a/src/components/Layouts/Header/style.ts
+++ b/src/components/Layouts/Header/style.ts
@@ -73,3 +73,26 @@ export const SettingContainer = styled.div`
     }
   }
 `;
+
+export const SettingHeaderContents = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  margin-left: 24px;
+`;
+
+export const PrevIconContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 50px;
+  height: 50px;
+  cursor: pointer;
+  border-radius: 50%;
+  &:hover {
+    background-color: ${({ theme }) => theme.button.quaternary.hover};
+  }
+`;

--- a/src/components/Layouts/Header/type.d.ts
+++ b/src/components/Layouts/Header/type.d.ts
@@ -1,0 +1,4 @@
+export interface SettingHeaderProps {
+  titleText: string;
+  redirect: string;
+}

--- a/src/components/Loading/Spinner.tsx
+++ b/src/components/Loading/Spinner.tsx
@@ -1,0 +1,9 @@
+import * as S from './style';
+
+export default function Spinner() {
+  return (
+    <>
+      <S.SpinnerDiv></S.SpinnerDiv>
+    </>
+  );
+}

--- a/src/components/Loading/index.ts
+++ b/src/components/Loading/index.ts
@@ -1,0 +1,1 @@
+export { default as Spinner } from './Spinner';

--- a/src/components/Loading/style.ts
+++ b/src/components/Loading/style.ts
@@ -1,0 +1,23 @@
+import styled, { keyframes } from 'styled-components';
+
+const rotation = keyframes`
+    from{
+        transform: rotate(0deg);
+    }
+
+    to{
+        transform: rotate(360deg);
+    }
+
+`;
+
+export const SpinnerDiv = styled.div`
+  height: 30px;
+  width: 30px;
+  border: 1px solid ${({ theme }) => theme.bg.primary};
+  border-radius: 50%;
+  border-top: none;
+  border-right: none;
+  margin: 0 auto;
+  animation: ${rotation} 1s linear infinite;
+`;

--- a/src/components/Svg/Svg.tsx
+++ b/src/components/Svg/Svg.tsx
@@ -91,3 +91,27 @@ export function InfoIcon({ size = '24' }: SvgProps) {
     </svg>
   );
 }
+
+export function EmailIcon({ color, size = '24' }: SvgProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      className="lucide lucide-mail w-6 h-6 text-rose-500"
+      data-id="element-8"
+    >
+      <rect width="20" height="16" x="2" y="4" rx="2"></rect>
+      <path
+        style={{ stroke: color }}
+        d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"
+      ></path>
+    </svg>
+  );
+}

--- a/src/components/Svg/Svg.tsx
+++ b/src/components/Svg/Svg.tsx
@@ -92,7 +92,7 @@ export function InfoIcon({ size = '24' }: SvgProps) {
   );
 }
 
-export function EmailIcon({ color, size = '24' }: SvgProps) {
+export function EmailIcon({ size = '24' }: SvgProps) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -101,17 +101,56 @@ export function EmailIcon({ color, size = '24' }: SvgProps) {
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
       className="lucide lucide-mail w-6 h-6 text-rose-500"
       data-id="element-8"
     >
       <rect width="20" height="16" x="2" y="4" rx="2"></rect>
-      <path
-        style={{ stroke: color }}
-        d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"
-      ></path>
+      <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"></path>
+    </svg>
+  );
+}
+
+export function KeyIcon({ size = '24' }: SvgProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="lucide lucide-key w-6 h-6 text-rose-500"
+      data-id="element-9"
+    >
+      <path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4"></path>
+      <path d="m21 2-9.6 9.6"></path>
+      <circle cx="7.5" cy="15.5" r="5.5"></circle>
+    </svg>
+  );
+}
+
+export function PrevIcon({ size = '24' }: SvgProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="lucide lucide-chevron-left w-6 h-6 text-gray-600"
+      data-id="element-4"
+    >
+      <path d="m15 18-6-6 6-6"></path>
     </svg>
   );
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,1 @@
+export * as Loading from './Loading';

--- a/src/store/authStore/index.ts
+++ b/src/store/authStore/index.ts
@@ -1,0 +1,1 @@
+export * as userInfoStore from './userInfoStore';

--- a/src/store/authStore/type.d.ts
+++ b/src/store/authStore/type.d.ts
@@ -1,0 +1,4 @@
+export interface UserInfoStoreType {
+  email: string;
+  setEmail: (email: string) => void;
+}

--- a/src/store/authStore/userInfoStore.ts
+++ b/src/store/authStore/userInfoStore.ts
@@ -1,0 +1,7 @@
+import { createStore } from 'zustand';
+import { UserInfoStoreType } from './type';
+
+export const useUserInfoStore = createStore<UserInfoStoreType>(set => ({
+  email: '',
+  setEmail: (email: string) => set({ email }),
+}));

--- a/src/styles/theme/color.ts
+++ b/src/styles/theme/color.ts
@@ -36,6 +36,7 @@ export const mainThemeColor: DefaultTheme = {
     primary: '#212121',
     secondary: '#FFFFFF',
     tertiary: '#757575',
+    quaternary: '#b45309',
   },
   shadow: {
     primary: '#D3D3D3',

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,6 +6,15 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["*"],
+      "@components/*": ["components/*"],
+      "@apis/*": ["apis/*"],
+      "@hook/*": ["hook/*"],
+      "@provider/*": ["utils/*"],
+      "@store/*": ["store/*"]
+    },
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,12 +8,7 @@
     "skipLibCheck": true,
     "baseUrl": "./src",
     "paths": {
-      "@/*": ["*"],
-      "@components/*": ["components/*"],
-      "@apis/*": ["apis/*"],
-      "@hook/*": ["hook/*"],
-      "@provider/*": ["utils/*"],
-      "@store/*": ["store/*"]
+      "@/*": ["*"]
     },
 
     /* Bundler mode */

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,9 +6,8 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "baseUrl": "./src",
     "paths": {
-      "@/*": ["*"]
+      "@/*": ["./src/*"]
     },
 
     /* Bundler mode */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,14 +3,5 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
-  ],
-  "compilerOptions": {
-    "paths": {
-      "@/*":["./src/*"],
-      "@components/*":["./src/components/*"],
-      "@apis/*":["./src/apis/*"],
-      "@hook/*":["./src/hook/*"],
-      "@provider/*":["./src/utils/*"],
-    }
-  }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,14 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
-  ]
+  ],
+  "compilerOptions": {
+    "paths": {
+      "@/*":["./src/*"],
+      "@components/*":["./src/components/*"],
+      "@apis/*":["./src/apis/*"],
+      "@hook/*":["./src/hook/*"],
+      "@provider/*":["./src/utils/*"],
+    }
+  }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react-swc';
+import path from 'path';
 
 // https://vite.dev/config/
 export default {
@@ -9,5 +10,8 @@ export default {
       enabled: true,
       name: 'chrome',
     },
+  },
+  resolve: {
+    alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
   },
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react-swc';
+import path from 'path';
 
 // https://vite.dev/config/
 export default {
@@ -9,5 +10,8 @@ export default {
       enabled: true,
       name: 'chrome',
     },
+  },
+  resolve: {
+    alias: [{ find: "@", replacement: path.resolve(__dirname, "src") }],
   },
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,4 @@
 import react from '@vitejs/plugin-react-swc';
-import path from 'path';
 
 // https://vite.dev/config/
 export default {
@@ -10,8 +9,5 @@ export default {
       enabled: true,
       name: 'chrome',
     },
-  },
-  resolve: {
-    alias: [{ find: "@", replacement: path.resolve(__dirname, "src") }],
   },
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> #8 

## 📝작업 내용

> 절대 경로 설정

- 절대경로 설정을 위한 `alias`를 추가했습니다.

> 로그인, 회원가입 에러 핸들링 로직 구현

- 우선 `alert`을 통해서 띄우도록 해놨습니다. 나중에 `modal`이나 `toast`형식으로 바꾸면 될 것 같습니다.

> 회원가입 후 이메일 로직

- 회원가입하는데 오류가 나서 왜인지 봤더니, 백엔드에서는 타임아웃을 5초로 줬는데, 프론트에서는 3초로 줘서 그랬습니다. 그만큼 이메일 로직이 백엔드에서 오래걸린다고 합니다. 이 부분은 나중에 개선한다고 합니다.
- 회원가입 후 이메일 발송 모달 퍼블리싱 진행
- 회원가입 후 이메일 발송하는 로직이 좀 오래걸려서, UX를 위한 `Loading-Spinner`를 추가했습니다. `Loading`에는 여러 모양이 있을 것 같아서, 나중에 컴포넌트를 추가해서 가져다가 쓰는 형식으로 사용하면 될 것 같습니다.

> 로그인 후

- 로그인 후 토큰을 `localStorage`에 저장했습니다.

> UserInfoStore추가

- 회원가입 이후, email에 대한 정보가 필요해서 `zustand`를 활용한 `UserInfo`를 상태관리 하였습니다.

> 비밀번호 변경을 위한 이메일 전송 로직 추가

- `Funnel`에 모달을 추가해서 로그인 하는 사용자가 쉽게 접근할 수 있도록 했음

> 비밀번호 변경 페이지 추가

- `usePrarms hook`을 사용해서 `url`의 정보를 받아옴

> Error Handler 추가

- 각 api에 맞는 `error`를 swagger를 보고 작성했습니다.

> alias를 통한 절대경로

- `alias`를 추가해서 절대경로를 `@`로 표시할 수 있도록 했습니다.


### 스크린샷 (선택)
이메일 인증 메일 전송 모달
![image](https://github.com/user-attachments/assets/bf2d3034-35fa-41e0-977b-62bd9628eb6a)

로딩 스피너
![image](https://github.com/user-attachments/assets/e0244dc5-525b-4434-91e7-0ba5ade22b76)

비밀번호 변경을 위한 이메일 전송
![image](https://github.com/user-attachments/assets/4371ce96-219a-4822-b85c-4dc9fbe39359)

비밀번호 변경 페이지
![image](https://github.com/user-attachments/assets/201eea8a-5656-4336-a835-0ed1224dee9b)
url주소에서 `token`과 `id`를 받아서 사용합니다.

## 💬리뷰 요구사항(선택)

