### PR TITLE
feat/woo(#3): 연결 모달 박스 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,10 @@ import ThemeColorProvider from './provider/ThemeColorProvider';
 import Root from './components/Root';
 import Main from './components/Main';
 import ChangePassword from './components/Auth/ChangePassword';
+import { useState } from 'react';
 
 function App() {
+  const [isTestOpen, setIsTestOpen] = useState<boolean>(false);
   return (
     <>
       <ThemeColorProvider>
@@ -16,6 +18,7 @@ function App() {
             path="/account/change-password/:token/:id"
             element={<ChangePassword />}
           />
+          <button>연결 모달 test</button>
         </AppProvider>
       </ThemeColorProvider>
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Root from './components/Root';
 import Main from './components/Main';
 import ChangePassword from './components/Auth/ChangePassword';
 import { useState } from 'react';
+import ConnectionModal from './components/Connection';
 
 function App() {
   const [isTestOpen, setIsTestOpen] = useState<boolean>(false);
@@ -18,8 +19,11 @@ function App() {
             path="/account/change-password/:token/:id"
             element={<ChangePassword />}
           />
-          <button>연결 모달 test</button>
         </AppProvider>
+        <button onClick={() => setIsTestOpen(prev => !prev)}>
+          연결 모달 test
+        </button>
+        <ConnectionModal isOpen={isTestOpen} />
       </ThemeColorProvider>
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,6 @@ import Root from './components/Root';
 import Main from './components/Main';
 
 function App() {
-  const [totalOpen, setTotalOpen] = useState<boolean>(false);
-
   return (
     <>
       <ThemeColorProvider>
@@ -17,16 +15,6 @@ function App() {
           <Route path="/honeyJar" element={<Main />}></Route>
         </AppProvider>
       </ThemeColorProvider>
-      <button onClick={() => setTotalOpen(!totalOpen)}>모달테스트</button>
-      <Modal isOpen={totalOpen}>
-        <div style={{ border: '1px solid red', backgroundColor: 'white' }}>
-          <h1>헤더</h1>
-          <div>
-            <h1>바디</h1>
-            <p>des</p>
-          </div>
-        </div>
-      </Modal>
     </>
   );
 }

--- a/src/components/Connection/index.tsx
+++ b/src/components/Connection/index.tsx
@@ -1,0 +1,15 @@
+import Modal from '@/components/Modal';
+import { ConnectionModalProps } from './type';
+import * as S from './style';
+
+export default function ConnectionModal({ isOpen }: ConnectionModalProps) {
+  return (
+    <Modal isOpen={isOpen}>
+      <S.ModalWrapper>
+        <S.ModalHeader>
+          <h2>사용자 검색</h2>
+        </S.ModalHeader>
+      </S.ModalWrapper>
+    </Modal>
+  );
+}

--- a/src/components/Connection/index.tsx
+++ b/src/components/Connection/index.tsx
@@ -1,14 +1,21 @@
 import Modal from '@/components/Modal';
 import { ConnectionModalProps } from './type';
 import * as S from './style';
+import { Svg } from '@/components/Svg';
+import { mainThemeColor } from '@/styles/theme';
 
 export default function ConnectionModal({ isOpen }: ConnectionModalProps) {
   return (
     <Modal isOpen={isOpen}>
       <S.ModalWrapper>
         <S.ModalHeader>
+          <Svg.SearchIcon color="red" />
           <h2>사용자 검색</h2>
         </S.ModalHeader>
+        <S.InputWrapper>
+          <S.SearchInput placeholder="이름으로 검색하기" />
+          <Svg.SearchIcon color={mainThemeColor.border.primary} />
+        </S.InputWrapper>
       </S.ModalWrapper>
     </Modal>
   );

--- a/src/components/Connection/style.ts
+++ b/src/components/Connection/style.ts
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+export const ModalWrapper = styled.div`
+  width: 350px;
+  padding: 24px;
+  border-radius: 16px;
+  background-color: ${({ theme }) => theme.bg.primary};
+`;
+export const ModalHeader = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  h2 {
+    font-size: 18px;
+    margin-left: 16px;
+    font-weight: 700;
+  }
+`;

--- a/src/components/Connection/style.ts
+++ b/src/components/Connection/style.ts
@@ -5,6 +5,8 @@ export const ModalWrapper = styled.div`
   padding: 24px;
   border-radius: 16px;
   background-color: ${({ theme }) => theme.bg.primary};
+  display: flex;
+  flex-direction: column;
 `;
 export const ModalHeader = styled.div`
   display: flex;
@@ -15,4 +17,19 @@ export const ModalHeader = styled.div`
     margin-left: 16px;
     font-weight: 700;
   }
+  margin-bottom: 12px;
+`;
+export const InputWrapper = styled.div`
+  border: 1px solid ${({ theme }) => theme.border.primary};
+  height: 42px;
+  border-radius: 8px;
+  display: flex;
+  overflow: hidden;
+  padding: 10px;
+  justify-content: space-between;
+  align-items: center;
+`;
+export const SearchInput = styled.input`
+  border: 0px;
+  outline: none;
 `;

--- a/src/components/Connection/type.d.ts
+++ b/src/components/Connection/type.d.ts
@@ -1,0 +1,3 @@
+export interface ConnectionModalProps {
+  isOpen: boolean;
+}

--- a/src/components/Svg/Svg.tsx
+++ b/src/components/Svg/Svg.tsx
@@ -154,3 +154,23 @@ export function PrevIcon({ size = '24' }: SvgProps) {
     </svg>
   );
 }
+export function SearchIcon({ size = '24' }: SvgProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="lucide lucide-search absolute left-3 top-2.5 text-gray-400"
+      data-id="element-8"
+    >
+      <circle cx="11" cy="11" r="8"></circle>
+      <path d="m21 21-4.3-4.3"></path>
+    </svg>
+  );
+}

--- a/src/components/Svg/Svg.tsx
+++ b/src/components/Svg/Svg.tsx
@@ -154,12 +154,12 @@ export function PrevIcon({ size = '24' }: SvgProps) {
     </svg>
   );
 }
-export function SearchIcon({ size = '24' }: SvgProps) {
+export function SearchIcon({ color, size = '24' }: SvgProps) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="20"
-      height="20"
+      width={size}
+      height={size}
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -168,8 +168,10 @@ export function SearchIcon({ size = '24' }: SvgProps) {
       strokeLinejoin="round"
       className="lucide lucide-search absolute left-3 top-2.5 text-gray-400"
       data-id="element-8"
+      style={{ color: color }}
     >
       <circle cx="11" cy="11" r="8"></circle>
+
       <path d="m21 21-4.3-4.3"></path>
     </svg>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

> #3 

## 📝작업 내용

> modal test 버튼 생성

연결 모달 구현 작업을 위해 '/' 루트에 테스트용 버튼을 생성했습니다.

> 기본 구성 퍼블리싱

현재 모달 박스, 헤더, 검색 input 및 search icon  form 정도만 구현 해놨고 
이후 작업부터 mock 데이터 활용해서 검색 후 결과화면을 이어서 구현 할 예정입니다.
mock 데이터는 api 개발 완료 후 교체하겠습니다.

### 스크린샷 (선택)
<img width="393" alt="image" src="https://github.com/user-attachments/assets/8ac60b67-ce49-49f1-9a35-7017e33d9567" />