### PR TITLE
인터셉터에 api-key추가

### DIFF
--- a/src/apis/interceptors.ts
+++ b/src/apis/interceptors.ts
@@ -2,10 +2,11 @@
 import { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 import { toast } from 'react-toastify';
 
+//요청 인터셉터
 export function CommonRequestInterceptor(
   config: InternalAxiosRequestConfig
 ): InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig> {
-  // Do something before request is sent
+  config.headers['X-Api-Key'] = import.meta.env.VITE_API_KEY;
   return config;
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #41 

## 📝작업 내용

> cors해결

- 백엔드에서 해결해줌

> 인터셉터에 추가

요청 인터셉터에
```javascript
//요청 인터셉터
export function CommonRequestInterceptor(
  config: InternalAxiosRequestConfig
): InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig> {
  config.headers['X-Api-Key'] = import.meta.env.VITE_API_KEY;
  return config;
}
```
header값 넣었음, 그냥 인스턴스에 박아도 되긴하는데, 다른 인스턴스에서 안쓰는 상황이 나올 수 있으니깐, 함수에 박아두고 나중에 바꾸게 되면 바꾸는게 좋을 것 같아서 그렇게 했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

