### PR TITLE
Feat/setting page/ljj

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { Main } from './components/Main';
 import { Post } from './components/Post';
 import { Honey } from './components/Main/Contents';
 import { Error } from './components';
+import { Setting } from './components/Setting';
 
 function App() {
   return (
@@ -21,6 +22,7 @@ function App() {
           />
           <Route path="/post" element={<Post />} />
           <Route path="/honey/:id" element={<Honey />} />
+          <Route path="/setting" element={<Setting />} />
           <Route path="*" element={<Error.NotFound />} />
         </AppProvider>
       </ThemeColorProvider>

--- a/src/apis/interceptors.ts
+++ b/src/apis/interceptors.ts
@@ -2,10 +2,11 @@
 import { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 import { toast } from 'react-toastify';
 
+//요청 인터셉터
 export function CommonRequestInterceptor(
   config: InternalAxiosRequestConfig
 ): InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig> {
-  // Do something before request is sent
+  config.headers['X-Api-Key'] = import.meta.env.VITE_API_KEY;
   return config;
 }
 

--- a/src/components/Auth/ChangePassword.tsx
+++ b/src/components/Auth/ChangePassword.tsx
@@ -54,7 +54,7 @@ export default function ChangePassword() {
 
   return (
     <>
-      <Header.SettingHeader titleText="비밀번호 변경" redirect="/root" />
+      <Header.SettingHeader titleText="비밀번호 변경" />
       <S.ChangePasswordWrapper>
         <S.ChangePasswordContainer>
           <S.KeyIconContainer>

--- a/src/components/Auth/LoginModal.tsx
+++ b/src/components/Auth/LoginModal.tsx
@@ -1,6 +1,6 @@
 import * as S from './style';
 import Image from '../Image';
-import { LoginInfo, ModalProps } from './type';
+import { AuthFunnelStep, LoginInfo, ModalProps } from './type';
 import { useState } from 'react';
 import { AuthQueries } from '@/apis/auth';
 import { validationLoginInfo } from './utils';
@@ -10,7 +10,7 @@ import { LoginErrorHandler } from '@/apis/auth/error';
 import { changeInfo } from '@/utils';
 import { toast } from 'react-toastify';
 
-export default function LoginModal({ setStep }: ModalProps) {
+export default function LoginModal({ setStep }: ModalProps<AuthFunnelStep>) {
   const [loginInfo, setLoginInfo] = useState<LoginInfo>({
     email: '',
     password: '',

--- a/src/components/Auth/RegisterModal.tsx
+++ b/src/components/Auth/RegisterModal.tsx
@@ -1,6 +1,6 @@
 import * as S from './style';
 import Image from '../Image';
-import { ModalProps, RegisterInfo } from './type';
+import { AuthFunnelStep, ModalProps, RegisterInfo } from './type';
 import { useEffect, useState } from 'react';
 import { Svg } from '../Svg';
 import { AuthQueries } from '@/apis/auth';
@@ -12,7 +12,7 @@ import { RegisterErrorHandler } from '@/apis/auth/error';
 import { changeInfo } from '@/utils';
 import { toast } from 'react-toastify';
 
-export default function RegisterModal({ setStep }: ModalProps) {
+export default function RegisterModal({ setStep }: ModalProps<AuthFunnelStep>) {
   const [registerInfo, setRegisterInfo] = useState<RegisterInfo>({
     email: '',
     password: '',

--- a/src/components/Auth/SendEmailForChnagePasswordModal.tsx
+++ b/src/components/Auth/SendEmailForChnagePasswordModal.tsx
@@ -9,9 +9,10 @@ import { AxiosError } from 'axios';
 import { SendEmailForChangePwErrorHandler } from '@/apis/auth/error';
 import { toast } from 'react-toastify';
 
-export default function SendEmailForChangePasswordModal({
+export default function SendEmailForChangePasswordModal<T>({
   setStep,
-}: ModalProps) {
+  redirect,
+}: ModalProps<T>) {
   const [forChangePw, setForChangePw] = useState<EmailForChangePwType>({
     email: '',
   });
@@ -74,9 +75,11 @@ export default function SendEmailForChangePasswordModal({
               <>비밀번호 변경 이메일 받기</>
             )}
           </button>
-          <button type="button" onClick={() => setStep('로그인')}>
-            취소
-          </button>
+          {redirect && (
+            <button type="button" onClick={() => setStep(redirect as T)}>
+              취소
+            </button>
+          )}
         </S.SendEmailBottom>
       </form>
     </S.ModalWrapper>

--- a/src/components/Auth/index.tsx
+++ b/src/components/Auth/index.tsx
@@ -40,7 +40,10 @@ export default function Auth() {
             <RegisterModal setStep={setStep} />
           </Funnel.Step>
           <Funnel.Step name="비밀번호 찾기">
-            <SendEmailForChangePasswordModal setStep={setStep} />
+            <SendEmailForChangePasswordModal
+              setStep={setStep}
+              redirect="로그인"
+            />
           </Funnel.Step>
           <Funnel.Step name="이메일 인증">
             <VerificationEmailModal />

--- a/src/components/Auth/type.d.ts
+++ b/src/components/Auth/type.d.ts
@@ -10,8 +10,9 @@ export interface SelectModalButton {
 }
 
 //모달 Props
-export interface ModalProps {
-  setStep: (step: AuthFunnelStep) => void;
+export interface ModalProps<T> {
+  setStep: (step: T) => void;
+  redirect?: string;
 }
 
 //회원가입 status

--- a/src/components/Layouts/Header/MainHeader.tsx
+++ b/src/components/Layouts/Header/MainHeader.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { Svg } from '../../Svg';
 import * as S from './style';
 
@@ -10,9 +11,11 @@ export default function MainHeader() {
       </S.TitleContainer>
       <S.SettingContainer>
         <button>공개글 보기</button>
-        <button>
-          <Svg.SettingIcon size={36} />
-        </button>
+        <Link to="/setting">
+          <button>
+            <Svg.SettingIcon size={36} />
+          </button>
+        </Link>
       </S.SettingContainer>
     </S.HeaderWrapper>
   );

--- a/src/components/Layouts/Header/SettingHeader.tsx
+++ b/src/components/Layouts/Header/SettingHeader.tsx
@@ -9,16 +9,13 @@ import { SettingHeaderProps } from './type';
  * @param titleText Header에 들어갈 페이지 이름
  * @returns Header 컴포넌트
  */
-export default function SettingHeader({
-  titleText,
-  redirect,
-}: SettingHeaderProps) {
+export default function SettingHeader({ titleText }: SettingHeaderProps) {
   const navigate = useNavigate();
 
   return (
     <S.HeaderWrapper>
       <S.SettingHeaderContents>
-        <S.PrevIconContainer onClick={() => navigate(redirect)}>
+        <S.PrevIconContainer onClick={() => navigate(-1)}>
           <Svg.PrevIcon />
         </S.PrevIconContainer>
         <h1>{titleText}</h1>

--- a/src/components/Layouts/Header/UnconnectedHeader.tsx
+++ b/src/components/Layouts/Header/UnconnectedHeader.tsx
@@ -1,5 +1,6 @@
 import { Svg } from '@/components/Svg';
 import * as S from './style';
+import { Link } from 'react-router-dom';
 
 export default function UnConnectedHeader() {
   return (
@@ -10,9 +11,11 @@ export default function UnConnectedHeader() {
       </S.UnConnectedTitleContainer>
       <S.SettingContainer>
         <button>공개글 보기</button>
-        <button>
-          <Svg.SettingIcon size={36} />
-        </button>
+        <Link to="/setting">
+          <button>
+            <Svg.SettingIcon size={36} />
+          </button>
+        </Link>
       </S.SettingContainer>
     </S.HeaderWrapper>
   );

--- a/src/components/Layouts/Header/style.ts
+++ b/src/components/Layouts/Header/style.ts
@@ -61,8 +61,10 @@ export const SettingContainer = styled.div`
   flex-direction: row;
   justify-content: space-between;
   margin: 20px 24px;
-  & > button {
+  button {
     background-color: inherit;
+    border: none;
+    cursor: pointer;
   }
   //공개글 보러가기 버튼
   & > button:nth-child(1) {
@@ -78,12 +80,11 @@ export const SettingContainer = styled.div`
     margin-right: 25px;
   }
   //설정 버튼
-  & > button:nth-child(2) {
+  & > :nth-child(2) {
     border: none;
     border-radius: 50%;
     padding: 12px;
     margin: 0px 12px;
-    cursor: pointer;
     &:hover {
       background-color: ${({ theme }) => theme.button.tertiary.hover};
     }

--- a/src/components/Layouts/Header/type.d.ts
+++ b/src/components/Layouts/Header/type.d.ts
@@ -1,4 +1,3 @@
 export interface SettingHeaderProps {
   titleText: string;
-  redirect: string;
 }

--- a/src/components/Setting/Setting.tsx
+++ b/src/components/Setting/Setting.tsx
@@ -1,0 +1,115 @@
+import { useTheme } from 'styled-components';
+import { Header } from '../Layouts';
+import * as S from './style';
+import { settingListType } from './type';
+import { Svg } from '../Svg';
+import { useState } from 'react';
+import useFunnel from '@/hook/useFunnel';
+import VerificationEmailModal from '../Auth/VerificationEmailModal';
+import Modal from '../Modal';
+import SendEmailForChangePasswordModal from '../Auth/SendEmailForChnagePasswordModal';
+
+export default function Setting() {
+  const theme = useTheme();
+  const [isOpenModal, setIsOpenModal] = useState(false);
+  const { Funnel, setStep } = useFunnel<'이메일 인증' | '비밀번호 변경'>(
+    '이메일 인증'
+  );
+
+  const settingList: settingListType[] = [
+    {
+      title: '계정',
+      contents: [
+        {
+          name: '계정 정보',
+          event: () => console.log('이메일 변경'),
+        },
+        {
+          name: '커플 프로필 관리',
+          event: () => console.log('비밀번호 변경'),
+        },
+        {
+          name: '이메일 인증',
+          event: () => {
+            setStep('이메일 인증');
+            setIsOpenModal(prev => !prev);
+          },
+        },
+        {
+          name: '비밀번호 변경',
+          event: () => {
+            setStep('비밀번호 변경');
+            setIsOpenModal(prev => !prev);
+          },
+        },
+        { name: '로그아웃', color: theme.accent },
+        { name: '회원탈퇴', color: theme.accent },
+      ],
+    },
+    {
+      title: '알림',
+      contents: [
+        {
+          name: '알림 설정',
+        },
+      ],
+    },
+    {
+      title: '앱 설정',
+      contents: [
+        {
+          name: '테마 설정',
+        },
+      ],
+    },
+    {
+      title: '지원',
+      contents: [
+        {
+          name: '고객지원',
+        },
+      ],
+    },
+  ];
+  return (
+    <>
+      <Modal isOpen={isOpenModal}>
+        <Funnel>
+          <Funnel.Step name="이메일 인증">
+            <VerificationEmailModal />
+          </Funnel.Step>
+          <Funnel.Step name="비밀번호 변경">
+            <SendEmailForChangePasswordModal setStep={setStep} />
+          </Funnel.Step>
+        </Funnel>
+      </Modal>
+      <Header.SettingHeader titleText="설정" />
+      <S.SettingWrapper>
+        <S.SettingListWrapper>
+          {settingList.map(item => {
+            return (
+              <S.SettingItem key={item.title}>
+                <S.SettingItemTitle>{item.title}</S.SettingItemTitle>
+                <S.SettingItemContents>
+                  {item.contents.map(content => {
+                    return (
+                      <S.SettingItemContentWrapper onClick={content.event}>
+                        <S.SettingItemContent
+                          key={content.name}
+                          color={content.color}
+                        >
+                          {content.name}
+                        </S.SettingItemContent>
+                        <Svg.NextIcon />
+                      </S.SettingItemContentWrapper>
+                    );
+                  })}
+                </S.SettingItemContents>
+              </S.SettingItem>
+            );
+          })}
+        </S.SettingListWrapper>
+      </S.SettingWrapper>
+    </>
+  );
+}

--- a/src/components/Setting/index.ts
+++ b/src/components/Setting/index.ts
@@ -1,0 +1,1 @@
+export { default as Setting } from './Setting';

--- a/src/components/Setting/style.ts
+++ b/src/components/Setting/style.ts
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+import { settingListType } from './type';
+
+export const SettingWrapper = styled.div`
+  width: 100%;
+  margin-top: 48px;
+  display: flex;
+  justify-content: center;
+`;
+
+export const SettingListWrapper = styled.ol`
+  width: 60%;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const SettingItem = styled.li`
+  width: 100%;
+  margin-bottom: 24px;
+`;
+
+export const SettingItemTitle = styled.div`
+  font-size: 24px;
+  font-weight: bold;
+  color: ${({ theme }) => theme.text.primary};
+  border-bottom: 1px solid ${({ theme }) => theme.border.primary};
+  margin-bottom: 16px;
+`;
+
+export const SettingItemContents = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 16px;
+  gap: 24px;
+  cursor: pointer;
+`;
+
+export const SettingItemContentWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const SettingItemContent = styled.div<
+  Pick<settingListType['contents'][number], 'color'>
+>`
+  font-size: 18px;
+  font-weight: 500;
+  color: ${({ color, theme }) => color || theme.text.primary};
+`;

--- a/src/components/Setting/type.d.ts
+++ b/src/components/Setting/type.d.ts
@@ -1,0 +1,8 @@
+export interface settingListType {
+  title: string;
+  contents: {
+    color?: string;
+    name: string;
+    event?: () => void;
+  }[];
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #40 

## 📝작업 내용

> 설청 페이지 퍼블리싱

- 설정페이지를 퍼블리싱 함
- 배열로 받아서 관리하기 쉽게 만들었음

> 비밀번호 변경 모달 추가

- 비밀번호 모달을 추가했음
- `useFunnel`을 사용한 이유는, 설정에서 사용될 기능들을 모달 형태로 빼서 작업을 할 것 같아서 우선 이렇게 진행
- 나중에 `SwitchCase` 고차 컴포넌트를 추가하면 바꿀 예정

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/2852060a-a3dd-42cc-a73d-605f17d8c25b)


## 💬리뷰 요구사항(선택)

> 렌더링

컴포넌트 내부에서 설정 리스트 배열을 선언했기 때문에, 컴포넌트가 렌더링 될 때 마다 새롭게 배열이 생성됩니다. 나중에 이 부분을 최적화 시켜야할 것 같은데 좋은 의견 있으면 주시면 감사합니다.
