### PR TITLE
프로필 퍼블리싱 및 리팩터링

### DIFF
--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { ImageComponentProps } from './type';
 import * as S from './style';
 /**
@@ -45,7 +45,7 @@ export default function Image({
   }, [preload, src]);
 
   // lazy 로딩
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!lazy || isLoaded) return;
 
     const handleScroll = () => {

--- a/src/components/Setting/Modals/EditCoupleProfileModal.tsx
+++ b/src/components/Setting/Modals/EditCoupleProfileModal.tsx
@@ -3,38 +3,26 @@ import * as S from './style';
 import Image from '@/components/Image';
 import { Svg } from '@/components/Svg';
 import { useTheme } from 'styled-components';
-import { CheckIsEdit } from './type';
+import { CoupleProfileInfoType, EditProfileInputOnFocusType } from './type';
 import { changeInfo } from '@/utils';
 
 export default function EditCoupleProfileModal() {
   const theme = useTheme();
-  const infoRef = useRef<HTMLInputElement[] | null[] | Array<string>>([
-    'bgImage',
-    'myProfile',
-    'partnerProfile',
-    'startDate',
-    'description',
-  ]);
-  const [coupleInfo, setCoupleInfo] = useState({
+  const coupleNameRef = useRef<HTMLInputElement>(null);
+  const coupleDescriptionRef = useRef<HTMLInputElement>(null);
+  const [coupleInfo, setCoupleInfo] = useState<CoupleProfileInfoType>({
     name: '우리의 이야기 저장소',
     description: '우리의 이야기를 저장하는 곳',
-    bgImage: '/images/introImage.jpg',
+    bgImage: 'images/introImage.jpg',
     myProfile: {
       name: '이재진',
-      image: '/images/introImage.jpg',
+      image: 'images/introImage.jpg',
     },
     partnerProfile: {
       name: '이재진',
-      image: '/images/introImage.jpg',
+      image: 'images/introImage.jpg',
     },
     startDate: '2016-04-21',
-  });
-  const [isEdits, setIsEdits] = useState<CheckIsEdit>({
-    bgImage: false,
-    myProfile: false,
-    partnerProfile: false,
-    startDate: false,
-    description: false,
   });
 
   const EditProfileImageOverlayComponent = ({
@@ -65,31 +53,42 @@ export default function EditCoupleProfileModal() {
     return Math.floor(days + 1);
   };
 
-  const editProfileDescription = changeInfo.text({
+  const onChangeProfileDescription = changeInfo.text<CoupleProfileInfoType>({
     setState: setCoupleInfo,
   });
-  const isEditDescription = () => {
-    changeInfo.toggle({
-      setState: setIsEdits,
-      key: 'description',
-    });
-    if (isEdits.description) {
-      if (infoRef.current[4] instanceof HTMLInputElement) {
-        infoRef.current[4].focus();
-      }
+  const onChangeProfileName = changeInfo.text<CoupleProfileInfoType>({
+    setState: setCoupleInfo,
+  });
+
+  const onEditProfileDescription = (ref: EditProfileInputOnFocusType) => {
+    if (ref.current) {
+      ref.current.disabled = false;
+      ref.current.focus();
     }
   };
 
-  console.log(infoRef);
+  const onSubmitEditProfile = () => {};
+  const onClickDisConnectedCouple = () => {};
+
   return (
     <S.ModalWrapper $width="650px">
-      <S.ModalHeader>
-        <h2>{coupleInfo.name}</h2>
-        <label>
+      <S.EditCoupleProfileTitleNameWrapper>
+        <input
+          id="name"
+          type="text"
+          value={coupleInfo.name}
+          disabled={true}
+          ref={coupleNameRef}
+          onChange={onChangeProfileName}
+        />
+        <label
+          htmlFor="name"
+          onClick={() => onEditProfileDescription(coupleNameRef)}
+        >
           <Svg.WriteIcon size={24} />
         </label>
-      </S.ModalHeader>
-      <form>
+      </S.EditCoupleProfileTitleNameWrapper>
+      <form onSubmit={onSubmitEditProfile}>
         <S.CoupleProfileWrapper>
           <EditProfileImageOverlayComponent htmlForId="previewCoupleBgImage">
             <Image
@@ -133,22 +132,28 @@ export default function EditCoupleProfileModal() {
                 type="text"
                 value={coupleInfo.description}
                 id="description"
-                className={
-                  isEdits.description
-                    ? 'read-only--description'
-                    : 'edit--description'
-                }
-                readOnly={!isEdits.description}
-                onChange={editProfileDescription}
-                ref={el => (infoRef.current[4] = el)}
+                disabled={false}
+                onChange={onChangeProfileDescription}
+                ref={coupleDescriptionRef}
               />
-              <label onFocus={isEditDescription}>
+              <label
+                onClick={() => onEditProfileDescription(coupleDescriptionRef)}
+              >
                 <Svg.WriteIcon size={16} />
               </label>
             </S.EditProfileDescription>
           </S.CoupleInfoGrid>
         </S.CoupleProfileInfoWrapper>
+        <S.SubmitEditProfileButtonWrapper>
+          <button type="submit">변경내용 저장</button>
+        </S.SubmitEditProfileButtonWrapper>
       </form>
+      <S.DisConnectedCoupleButtonWrapper>
+        <S.DisConnectedCoupleButton>
+          <Svg.DisConnectedCoupleIcon onClick={onClickDisConnectedCouple} />
+          커플 연결 해제
+        </S.DisConnectedCoupleButton>
+      </S.DisConnectedCoupleButtonWrapper>
     </S.ModalWrapper>
   );
 }

--- a/src/components/Setting/Modals/EditCoupleProfileModal.tsx
+++ b/src/components/Setting/Modals/EditCoupleProfileModal.tsx
@@ -1,10 +1,11 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import * as S from './style';
 import Image from '@/components/Image';
 import { Svg } from '@/components/Svg';
 import { useTheme } from 'styled-components';
 import { CoupleProfileInfoType, EditProfileInputOnFocusType } from './type';
 import { changeInfo } from '@/utils';
+import EditProfileImageOverlayComponent from './EditProfileImageOverlayComponent';
 
 export default function EditCoupleProfileModal() {
   const theme = useTheme();
@@ -13,35 +14,24 @@ export default function EditCoupleProfileModal() {
   const [coupleInfo, setCoupleInfo] = useState<CoupleProfileInfoType>({
     name: '우리의 이야기 저장소',
     description: '우리의 이야기를 저장하는 곳',
-    bgImage: 'images/introImage.jpg',
+    bgImage: {} as File,
+    blobImage: 'images/introImage.jpg',
     myProfile: {
       name: '이재진',
-      image: 'images/introImage.jpg',
+      image: {} as File,
+      blobImage: 'images/introImage.jpg',
     },
     partnerProfile: {
       name: '이재진',
-      image: 'images/introImage.jpg',
+      image: {} as File,
+      blobImage: 'images/introImage.jpg',
     },
     startDate: '2016-04-21',
   });
-
-  const EditProfileImageOverlayComponent = ({
-    children,
-    htmlForId,
-  }: {
-    children: React.ReactNode;
-    htmlForId: string;
-  }) => {
-    return (
-      <S.EditProfileImageOverlay>
-        {children}
-        <label htmlFor={htmlForId}>
-          <Svg.CameraIcon />
-        </label>
-        <input type="file" id={htmlForId} hidden />
-      </S.EditProfileImageOverlay>
-    );
-  };
+  const [isEditing, setIsEditing] = useState({
+    name: true,
+    description: true,
+  });
 
   const calculateDurationRelationship = () => {
     const startDate = new Date(coupleInfo.startDate);
@@ -60,14 +50,67 @@ export default function EditCoupleProfileModal() {
     setState: setCoupleInfo,
   });
 
-  const onEditProfileDescription = (ref: EditProfileInputOnFocusType) => {
+  const onChangeCoupleBgImage = changeInfo.image<CoupleProfileInfoType>({
+    setState: setCoupleInfo,
+  });
+
+  const onChangeMyProfileImage = changeInfo.image<CoupleProfileInfoType>({
+    setState: setCoupleInfo,
+    depth: 'myProfile',
+  });
+
+  const onChangePartnerProfileImage = changeInfo.image<CoupleProfileInfoType>({
+    setState: setCoupleInfo,
+    depth: 'partnerProfile',
+  });
+  const onEditProfileTextInfo = (ref: EditProfileInputOnFocusType) => {
     if (ref.current) {
       ref.current.disabled = false;
+      setIsEditing(prev => {
+        return {
+          ...prev,
+          [`${ref.current?.id}`]: false,
+        };
+      });
       ref.current.focus();
     }
   };
 
-  const onSubmitEditProfile = () => {};
+  useEffect(() => {
+    // 특정 영역 외 클릭 시 발생하는 이벤트
+    function handleFocus(ref: EditProfileInputOnFocusType) {
+      if (ref.current) {
+        ref.current.disabled = true;
+        setIsEditing(prev => {
+          return {
+            ...prev,
+            [`${ref.current?.id}`]: true,
+          };
+        });
+      }
+    }
+
+    // 이벤트 리스너에 handleFocus 함수 등록
+    document.addEventListener('mouseup', () => handleFocus(coupleNameRef));
+    document.addEventListener('mouseup', () =>
+      handleFocus(coupleDescriptionRef)
+    );
+    return () => {
+      document.removeEventListener('mouseup', () => handleFocus(coupleNameRef));
+      document.removeEventListener('mouseup', () =>
+        handleFocus(coupleDescriptionRef)
+      );
+    };
+  }, [coupleNameRef, coupleDescriptionRef]);
+
+  const onSubmitEditProfile = () => {
+    //api로 담아보낼 from데이터
+    const formData = new FormData();
+    formData.append('file', coupleInfo.bgImage);
+    formData.append('file', coupleInfo.myProfile.image);
+    formData.append('file', coupleInfo.partnerProfile.image);
+    //api요청 로직 추가 예정
+  };
   const onClickDisConnectedCouple = () => {};
 
   return (
@@ -77,22 +120,25 @@ export default function EditCoupleProfileModal() {
           id="name"
           type="text"
           value={coupleInfo.name}
-          disabled={true}
+          disabled={isEditing.name}
           ref={coupleNameRef}
           onChange={onChangeProfileName}
         />
         <label
           htmlFor="name"
-          onClick={() => onEditProfileDescription(coupleNameRef)}
+          onClick={() => onEditProfileTextInfo(coupleNameRef)}
         >
           <Svg.WriteIcon size={24} />
         </label>
       </S.EditCoupleProfileTitleNameWrapper>
       <form onSubmit={onSubmitEditProfile}>
         <S.CoupleProfileWrapper>
-          <EditProfileImageOverlayComponent htmlForId="previewCoupleBgImage">
+          <EditProfileImageOverlayComponent
+            htmlForId="bgImage"
+            onChange={onChangeCoupleBgImage}
+          >
             <Image
-              src={coupleInfo.bgImage}
+              src={coupleInfo.blobImage}
               alt="bgImage"
               width="100%"
               height="220px"
@@ -102,9 +148,12 @@ export default function EditCoupleProfileModal() {
         </S.CoupleProfileWrapper>
         <S.CoupleProfileInfoWrapper>
           <S.CoupleInfoGrid>
-            <EditProfileImageOverlayComponent htmlForId="previewMyProfileImage">
+            <EditProfileImageOverlayComponent
+              htmlForId="myProfileImage"
+              onChange={onChangeMyProfileImage}
+            >
               <Image
-                src={coupleInfo.myProfile.image}
+                src={coupleInfo.myProfile.blobImage}
                 alt="profile"
                 width="80px"
                 height="80px"
@@ -115,9 +164,12 @@ export default function EditCoupleProfileModal() {
               <Svg.LikeIcon color={theme.accent} />
               <div>+ {calculateDurationRelationship()}</div>
             </S.DuringRelationshipDateWrapper>
-            <EditProfileImageOverlayComponent htmlForId="previewPartnerProfileImage">
+            <EditProfileImageOverlayComponent
+              htmlForId="partnerProfileImage"
+              onChange={onChangePartnerProfileImage}
+            >
               <Image
-                src={coupleInfo.myProfile.image}
+                src={coupleInfo.partnerProfile.blobImage}
                 alt="profile"
                 width="80px"
                 height="80px"
@@ -132,12 +184,12 @@ export default function EditCoupleProfileModal() {
                 type="text"
                 value={coupleInfo.description}
                 id="description"
-                disabled={false}
+                disabled={isEditing.description}
                 onChange={onChangeProfileDescription}
                 ref={coupleDescriptionRef}
               />
               <label
-                onClick={() => onEditProfileDescription(coupleDescriptionRef)}
+                onClick={() => onEditProfileTextInfo(coupleDescriptionRef)}
               >
                 <Svg.WriteIcon size={16} />
               </label>

--- a/src/components/Setting/Modals/EditMyProfileModal.tsx
+++ b/src/components/Setting/Modals/EditMyProfileModal.tsx
@@ -2,12 +2,12 @@ import Image from '@/components/Image';
 import * as S from './style';
 import { Svg } from '@/components/Svg';
 import { useState } from 'react';
-import { currentProfileInfoType } from './type';
+import { CurrentProfileInfoType } from './type';
 import { changeInfo } from '@/utils';
 
 export default function EditMyProfileModal() {
   const [currentProfileInfo, setCurrentProfileInfo] =
-    useState<currentProfileInfoType>({
+    useState<CurrentProfileInfoType>({
       editName: '이재진',
       editImage: {} as File,
       blobImage: 'images/introImage.jpg',
@@ -31,7 +31,7 @@ export default function EditMyProfileModal() {
     }
   };
 
-  const onChangeName = changeInfo.text<currentProfileInfoType>({
+  const onChangeName = changeInfo.text<CurrentProfileInfoType>({
     setState: setCurrentProfileInfo,
   });
 

--- a/src/components/Setting/Modals/EditMyProfileModal.tsx
+++ b/src/components/Setting/Modals/EditMyProfileModal.tsx
@@ -13,23 +13,9 @@ export default function EditMyProfileModal() {
       blobImage: 'images/introImage.jpg',
     });
 
-  const profileImageToUploadFile: React.ChangeEventHandler<
-    HTMLInputElement
-  > = e => {
-    if (!e.target.files) {
-      return;
-    }
-    const file = e.target.files;
-    if (file) {
-      setCurrentProfileInfo(prev => {
-        return {
-          ...prev,
-          editImage: file[0],
-          blobImage: URL.createObjectURL(file[0]),
-        };
-      });
-    }
-  };
+  const profileImageToUploadFile = changeInfo.image<CurrentProfileInfoType>({
+    setState: setCurrentProfileInfo,
+  });
 
   const onChangeName = changeInfo.text<CurrentProfileInfoType>({
     setState: setCurrentProfileInfo,
@@ -59,13 +45,13 @@ export default function EditMyProfileModal() {
                 height="80px"
                 borderRadius="50%"
               />
-              <label htmlFor="previewProfileImage">
+              <label htmlFor="editImage">
                 <Svg.CameraIcon />
               </label>
               <input
                 type="file"
                 accept="image/*"
-                id="previewProfileImage"
+                id="editImage"
                 onChange={profileImageToUploadFile}
                 hidden
               />

--- a/src/components/Setting/Modals/EditProfileImageOverlayComponent.tsx
+++ b/src/components/Setting/Modals/EditProfileImageOverlayComponent.tsx
@@ -1,0 +1,25 @@
+import { Svg } from '@/components/Svg';
+import * as S from './style';
+import { EditProfileImageOverlayComponentProps } from './type';
+
+export default function EditProfileImageOverlayComponent({
+  children,
+  htmlForId,
+  onChange,
+}: EditProfileImageOverlayComponentProps) {
+  return (
+    <S.EditProfileImageOverlay>
+      {children}
+      <label htmlFor={htmlForId}>
+        <Svg.CameraIcon />
+      </label>
+      <input
+        type="file"
+        accept="image/*"
+        id={htmlForId}
+        onChange={onChange}
+        hidden
+      />
+    </S.EditProfileImageOverlay>
+  );
+}

--- a/src/components/Setting/Modals/style.ts
+++ b/src/components/Setting/Modals/style.ts
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 interface ModalWrapperProps {
   $width?: string;
@@ -163,6 +163,30 @@ export const CoupleProfileWrapper = styled.div`
   margin-top: 24px;
 `;
 
+export const EditCoupleProfileTitleNameWrapper = styled.div`
+  display: flex;
+  justify-content: start;
+  align-items: center;
+  gap: 16px;
+  //커플 프로필 이름 수정
+  input {
+    padding: 8px 16px;
+    border-radius: 8px;
+    border: none;
+    background-color: ${({ theme }) => theme.bg.secondary};
+    color: ${({ theme }) => theme.text.primary};
+  }
+  label {
+    cursor: pointer;
+    padding: 8px;
+    background-color: ${({ theme }) => theme.button.tertiary.base};
+    border-radius: 50%;
+    &:hover {
+      background-color: ${({ theme }) => theme.button.tertiary.hover};
+    }
+  }
+`;
+
 export const CoupleProfileInfoWrapper = styled.div`
   display: flex;
   justify-content: center;
@@ -185,15 +209,6 @@ export const DuringRelationshipDateWrapper = styled.div`
   justify-content: end;
 `;
 
-const descriptionStyle = css`
-  padding: 8px 16px;
-  border-radius: 8px;
-  width: 100%;
-  border: none;
-  background-color: ${({ theme }) => theme.bg.secondary};
-  color: ${({ theme }) => theme.text.primary};
-`;
-
 export const EditProfileDescription = styled.div`
   margin-top: 12px;
   grid-column: 1 / 4;
@@ -202,12 +217,13 @@ export const EditProfileDescription = styled.div`
   justify-content: center;
   align-items: center;
   gap: 16px;
-  .read-only--description {
-    ${descriptionStyle}
-    outline: none;
-  }
-  .edit--description {
-    ${descriptionStyle}
+  input {
+    padding: 8px 16px;
+    border-radius: 8px;
+    width: 100%;
+    border: none;
+    background-color: ${({ theme }) => theme.bg.secondary};
+    color: ${({ theme }) => theme.text.primary};
   }
   label {
     cursor: pointer;
@@ -217,5 +233,51 @@ export const EditProfileDescription = styled.div`
     &:hover {
       background-color: ${({ theme }) => theme.button.tertiary.hover};
     }
+  }
+`;
+
+export const SubmitEditProfileButtonWrapper = styled.div`
+  display: flex;
+  justify-content: end;
+  margin-top: 24px;
+  //edit profile 버튼
+  button {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 8px;
+    background-color: ${({ theme }) => theme.button.primary.base};
+    color: ${({ theme }) => theme.text.secondary};
+    font-weight: 700;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+    &:hover {
+      background-color: ${({ theme }) => theme.button.primary.hover};
+    }
+  }
+`;
+
+export const DisConnectedCoupleButtonWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 24px;
+  //커플 연결 해제 버튼
+`;
+
+export const DisConnectedCoupleButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: ${({ theme }) => theme.accent};
+  gap: 12px;
+  padding: 8px 16px;
+  border: none;
+  background-color: inherit;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  &:hover {
+    background-color: ${({ theme }) => theme.button.secondary.hover};
+    color: ${({ theme }) => theme.text.secondary};
   }
 `;

--- a/src/components/Setting/Modals/type.d.ts
+++ b/src/components/Setting/Modals/type.d.ts
@@ -4,19 +4,26 @@ export interface CurrentProfileInfoType {
   blobImage: string;
 }
 
+type ProfileInfo = {
+  name: string;
+  image: File;
+  blobImage: string;
+};
+
 export interface CoupleProfileInfoType {
   name: string;
   description: string;
-  bgImage: string;
-  myProfile: {
-    name: string;
-    image: string;
-  };
-  partnerProfile: {
-    name: string;
-    image: string;
-  };
+  bgImage: File;
+  blobImage: string;
+  myProfile: ProfileInfo;
+  partnerProfile: ProfileInfo;
   startDate: string;
 }
 
 export type EditProfileInputOnFocusType = React.RefObject<HTMLInputElement>;
+
+export interface EditProfileImageOverlayComponentProps {
+  children: React.ReactNode;
+  htmlForId: string;
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+}

--- a/src/components/Setting/Modals/type.d.ts
+++ b/src/components/Setting/Modals/type.d.ts
@@ -1,13 +1,22 @@
-export interface currentProfileInfoType {
+export interface CurrentProfileInfoType {
   editName: string;
   editImage: File;
   blobImage: string;
 }
 
-export interface CheckIsEdit {
-  bgImage: boolean;
-  myProfile: boolean;
-  partnerProfile: boolean;
-  startDate: boolean;
-  description: boolean;
+export interface CoupleProfileInfoType {
+  name: string;
+  description: string;
+  bgImage: string;
+  myProfile: {
+    name: string;
+    image: string;
+  };
+  partnerProfile: {
+    name: string;
+    image: string;
+  };
+  startDate: string;
 }
+
+export type EditProfileInputOnFocusType = React.RefObject<HTMLInputElement>;

--- a/src/components/Svg/Svg.tsx
+++ b/src/components/Svg/Svg.tsx
@@ -417,3 +417,27 @@ export function CameraIcon({ color, size = 24 }: SvgProps) {
     </svg>
   );
 }
+
+export function DisConnectedCoupleIcon({ color, size = '24' }: SvgProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="lucide lucide-user-x w-5 h-5 mr-2"
+      data-id="element-42"
+      style={{ color: color }}
+    >
+      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"></path>
+      <circle cx="9" cy="7" r="4"></circle>
+      <line x1="17" x2="22" y1="8" y2="13"></line>
+      <line x1="22" x2="17" y1="8" y2="13"></line>
+    </svg>
+  );
+}

--- a/src/utils/changeInfo/image.ts
+++ b/src/utils/changeInfo/image.ts
@@ -1,0 +1,57 @@
+interface onChangeImageInfoParams<T> {
+  setState: React.Dispatch<React.SetStateAction<T>>;
+  depth?: string;
+}
+
+/**
+ *
+ * @param setState 사용하는 부분에서 선언하는 setState함수
+ * @param depth state의 깊이가 있는 경우 해당 깊이를 입력
+ * @returns setState함수를 이용하여 이미지 정보를 변경
+ *
+ * @description input file에 대한 이벤트 핸들러에 id와, state의 이름을 일치 시켜야 함
+ *
+ * @example
+ *     const [currentProfileInfo, setCurrentProfileInfo] = useState<CurrentProfileInfoType>({
+ *      editName: '이재진',
+ *      editImage: {} as File,
+ *      blobImage: 'images/introImage.jpg',
+ *  });
+ *
+ *  const onChangeMyProfileImage = changeInfo.image<CurrentProfileInfoType>({setState: setCurrentProfileInfo});
+ *
+ *  return (
+ *      <input type="file" id="editImage" onChange={onChangeMyProfileImage} />
+ *  )
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function onChangeImageInfo<T extends Record<string, any>>({
+  setState,
+  depth,
+}: onChangeImageInfoParams<T>): React.ChangeEventHandler<HTMLInputElement> {
+  return e => {
+    const { id, files } = e.target;
+    if (!files || files.length === 0) {
+      return;
+    }
+    if (files) {
+      setState(prev => {
+        if (depth) {
+          return {
+            ...prev,
+            [depth]: {
+              ...prev[depth],
+              [id]: files[0],
+              blobImage: URL.createObjectURL(files[0]),
+            },
+          };
+        }
+        return {
+          ...prev,
+          [id]: files[0],
+          blobImage: URL.createObjectURL(files[0]),
+        };
+      });
+    }
+  };
+}

--- a/src/utils/changeInfo/index.ts
+++ b/src/utils/changeInfo/index.ts
@@ -1,2 +1,3 @@
 export { default as text } from './text';
 export { default as toggle } from './toggle';
+export { default as image } from './image';


### PR DESCRIPTION
## #️⃣연관된 이슈

> #38 
## 📝작업 내용

> 점멸 현상 개선

[정리 내용 링크](https://www.notion.so/onChange-18a29d6fc06d80dba9b9cf62fffa67bd)

> focus 기능 추가

- 연필 버튼을 누르면, 포커스가 조정됩니다.
- ref을 배열 형태로 가져가서 관리하기 쉽게 만들려고 했는데, 생각보다 소요가 있는 작업이라 판단이 돼서 그냥 진행했습니다.

### 스크린샷 (선택)

![스크린샷 2025-01-29 223250](https://github.com/user-attachments/assets/6ccfef73-6dd2-4841-8cbf-c1fd3f30db1a)

## 💬리뷰 요구사항(선택)

> 추가 리팩터링

- 노션 정리글 마지막 부분에 언급한 내용입니다.
- 이번에 점멸현상을 개선하기 위해서 `Image 컴포넌트` 에서 `lazy-load`하는 역할을 하던 `useEffect`를 `useLayoutEffect`로 변경했습니다. 근데 만들면서 `useEffect`를 사용하는 경우는 없을까? 하는 생각이 들더라구요, 그래서 아마 `props`로 전달받은 값에 따라서 `useEffect`를 사용할지 `useLayoutEffect`를 사용할지 조건을 사용하는 로직으로 변경할까 하는데 어떤가요? 불필요한 작업일 수 있어서 여기서 여쭤봅니다.
