### PR TITLE
refactor/LJJ(#57): theme 타입 추론

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/node": "^22.10.5",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
+        "@types/styled-components": "^5.1.34",
         "@vitejs/plugin-react-swc": "^3.5.0",
         "@vitest/browser": "^2.1.8",
         "eslint": "^9.17.0",
@@ -3688,6 +3689,17 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
+      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -3820,6 +3832,18 @@
       "integrity": "sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/styled-components": {
+      "version": "5.1.34",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.34.tgz",
+      "integrity": "sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "*",
+        "@types/react": "*",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/@types/stylis": {
       "version": "4.2.5",
@@ -8050,6 +8074,23 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/node": "^22.10.5",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
+    "@types/styled-components": "^5.1.34",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "@vitest/browser": "^2.1.8",
     "eslint": "^9.17.0",

--- a/src/components/PopUp/style.ts
+++ b/src/components/PopUp/style.ts
@@ -24,7 +24,7 @@ export const TooltipTextDiv = styled.div<TooltipDirectionProps>`
   z-index: 5;
   padding: 5px;
   background-color: ${({ theme }) => theme.bg.primary};
-  border: 1px solid ${({ theme }) => theme.border.tertiary};
+  border: 1px solid ${({ theme }) => theme.border.primary};
   border-radius: 5px;
   font-size: 12px;
   white-space: nowrap;

--- a/src/styles/theme/color.ts
+++ b/src/styles/theme/color.ts
@@ -38,7 +38,7 @@ export const mainThemeColor: DefaultTheme = {
     primary: '#D3D3D3',
   },
   accent: '#e11d48',
-};
+} as const;
 
 export const darkThemeColor: DefaultTheme = {
   bg: {
@@ -75,4 +75,6 @@ export const darkThemeColor: DefaultTheme = {
     primary: '#000000', // 어두운 그림자 색상
   },
   accent: '#FF4081', // 강조 색상
-};
+} as const;
+
+export type MainThemeColor = typeof mainThemeColor;

--- a/src/styles/theme/type.d.ts
+++ b/src/styles/theme/type.d.ts
@@ -1,0 +1,40 @@
+import 'styled-components';
+import { MainThemeColor } from './color';
+
+declare module 'styled-components' {
+  export interface DefaultTheme extends MainThemeColor {
+    bg: {
+      primary: string;
+      secondary: string;
+      tertiary: string;
+    };
+    button: {
+      primary: {
+        base: string;
+        hover: string;
+      };
+      secondary: {
+        base: string;
+        hover: string;
+      };
+      tertiary: {
+        base: string;
+        hover: string;
+      };
+    };
+    border: {
+      primary: string;
+      secondary: string;
+    };
+    text: {
+      primary: string;
+      secondary: string;
+      tertiary: string;
+      quaternary: string;
+    };
+    shadow: {
+      primary: string;
+    };
+    accent: string;
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #57

## 📝작업 내용

> styled-component theme type 추론

- 공식문서에서 제안한 대로 진행했습니다. 
- `@type/styled-components` 를 다운해야 한다 해서 다운했습니다.

[공식문서 - 링크](https://styled-components.com/docs/api#typescript)

### 스크린샷 (선택)

![스크린샷 2025-02-02 172716](https://github.com/user-attachments/assets/f79e1960-cf0c-4357-a604-1157ddcd8cab)

## 💬리뷰 요구사항(선택)

