### PR TITLE
설정 페이지 기능 추가

### DIFF
--- a/src/apis/blog/queries.ts
+++ b/src/apis/blog/queries.ts
@@ -163,6 +163,7 @@ export const GetPrivateBlogPaginationQuery = (
         ? allPages.currentPage + 1
         : undefined;
     },
+
     retry: false,
     refetchOnWindowFocus: false,
     enabled: !!params.id,

--- a/src/apis/interceptors.ts
+++ b/src/apis/interceptors.ts
@@ -17,9 +17,12 @@ export function TokenRequestInterceptor(
   config: InternalAxiosRequestConfig
 ): InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig> {
   config.headers['X-Api-Key'] = import.meta.env.VITE_API_KEY;
-  config.headers['Authorization'] = `Bearer ${window.localStorage.getItem(
-    'accessToken'
-  )}`;
+  const accessToken = window.localStorage.getItem('accessToken');
+  if (accessToken) {
+    config.headers['Authorization'] = `Bearer ${accessToken}`;
+  } else {
+    throw new Error('로그인한 사용자가 아닙니다.');
+  }
   return config;
 }
 
@@ -53,6 +56,9 @@ export async function ErrorInterceptor(error: AxiosError) {
         toast.error('토근 재발급에 실패했습니다. 다시 로그인 해 주세요');
         window.location.href = '/root';
         window.localStorage.clear();
+        return;
+      } else {
+        toast.error('서버 오류 입니다. 잠시 후 다시 시도해주세요.');
         return;
       }
     }

--- a/src/apis/user/endpoint.ts
+++ b/src/apis/user/endpoint.ts
@@ -27,3 +27,9 @@ export async function postReissueEmailVerifyToken(): Promise<void> {
   );
   return response.data;
 }
+
+//회원 탈퇴
+export async function deleteUser(): Promise<void> {
+  const response = await instanceToken.delete('/users/me');
+  return response.data;
+}

--- a/src/apis/user/error.ts
+++ b/src/apis/user/error.ts
@@ -29,3 +29,11 @@ export function reissueEmailVerifyTokenErrorHandler(error: AxiosError) {
     return '요청하신 이메일로 이미 인증 메일을 보냈습니다. 이메일을 확인해 주세요.';
   }
 }
+
+export function deleteUserErrorHandler(error: AxiosError) {
+  const responseData = error.response?.data as ErrorResponse;
+  const { code } = responseData;
+  if (code === 'RESOURCE_NOT_FOUND') {
+    return '이미 삭제되었거나, 존재하지 않는 유저 입니다.';
+  }
+}

--- a/src/apis/user/queries.ts
+++ b/src/apis/user/queries.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { UserEndPoint } from '.';
 import { toast } from 'react-toastify';
 import {
+  deleteUserErrorHandler,
   EditMyInfoErrorHandler,
   MyInfoErrorHandler,
   reissueEmailVerifyTokenErrorHandler,
@@ -10,7 +11,7 @@ import { AxiosError } from 'axios';
 
 export function GetMyInfoQuery() {
   const { data, isError, error } = useQuery({
-    queryKey: ['users-me', 'get'],
+    queryKey: ['users-me'],
     queryFn: UserEndPoint.getMyInfo,
     enabled: !!localStorage.getItem('accessToken'),
     refetchOnWindowFocus: false,
@@ -27,8 +28,11 @@ export function EditMyInfoMutation() {
   return useMutation({
     mutationFn: UserEndPoint.patchMyInfo,
     onSuccess: () => {
-      return queryClient.invalidateQueries({
-        queryKey: ['users-me', 'patch'],
+      queryClient.invalidateQueries({
+        queryKey: ['users-me'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['single-blog'],
       });
     },
     onError: (error: AxiosError) => {
@@ -48,6 +52,21 @@ export function ReissueEmailVerifyTokenMutate() {
     },
     onError: (error: AxiosError) => {
       toast.error(reissueEmailVerifyTokenErrorHandler(error as AxiosError));
+    },
+  });
+}
+
+export function DeleteUserMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: UserEndPoint.deleteUser,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['users-me'],
+      });
+    },
+    onError: (error: AxiosError) => {
+      toast.error(deleteUserErrorHandler(error));
     },
   });
 }

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -18,13 +18,13 @@ export default function Main() {
   });
   const { value: token } = useLocalStorage('accessToken');
   const getMyInfo = UserQueries.GetMyInfoQuery();
-  const getBlogInfo = BlogQueries.GetSingleBlogQuery(getMyInfo?.id as string);
+  const getBlogInfo = BlogQueries.GetSingleBlogQuery(getMyInfo?.id);
 
   useEffect(() => {
-    if (connectionInfo?.contents && getBlogInfo) {
+    if (connectionInfo && connectionInfo?.contents.length > 0) {
       setIsCreateBlogModal(true);
     }
-  }, [getBlogInfo, connectionInfo]);
+  }, [connectionInfo?.contents]);
 
   if (getBlogInfo) {
     return <Navigate to={`/blog/${getBlogInfo.id}`} />;
@@ -39,14 +39,16 @@ export default function Main() {
       <Header.UnConnectedHeader />
       <S.ContentsWrapper>
         <SideNavigate.UnConnectedSideNav />
-        <Modal
-          shouldCloseToClickOutside={false}
-          blur={true}
-          isShow={isCreateBlogModal}
-          setIsShow={setIsCreateBlogModal}
-        >
-          <CreateBlogModal />
-        </Modal>
+        {isCreateBlogModal && (
+          <Modal
+            shouldCloseToClickOutside={false}
+            blur={true}
+            isShow={isCreateBlogModal}
+            setIsShow={setIsCreateBlogModal}
+          >
+            <CreateBlogModal />
+          </Modal>
+        )}
 
         <div>
           <Profile.UnConnectedProfile />

--- a/src/components/Setting/Setting.tsx
+++ b/src/components/Setting/Setting.tsx
@@ -11,9 +11,13 @@ import ChangeThemeModal from './Modals/ChangeThemeModal';
 import EditCoupleProfileModal from './Modals/EditCoupleProfileModal';
 import EditMyProfileModal from './Modals/EditMyProfileModal';
 import EmailValidationModal from './Modals/EmailValidationModal';
+import { toast } from 'react-toastify';
+import { UserEndPoint } from '@/apis/user';
+import { useNavigate } from 'react-router-dom';
 
 export default function Setting() {
   const theme = useTheme();
+  const navigate = useNavigate();
   const [isOpenModal, setIsOpenModal] = useState(false);
   const { Funnel, setStep } = useFunnel<
     | '이메일 인증'
@@ -55,15 +59,33 @@ export default function Setting() {
             setIsOpenModal(prev => !prev);
           },
         },
-        { name: '로그아웃', color: theme.accent },
-        { name: '회원탈퇴', color: theme.accent },
-      ],
-    },
-    {
-      title: '알림',
-      contents: [
         {
-          name: '알림 설정',
+          name: '로그아웃',
+          color: theme.accent,
+          event: () => {
+            window.localStorage.removeItem('accessToken');
+            window.localStorage.removeItem('refreshToken');
+            window.location.href = '/root';
+          },
+        },
+        {
+          name: '회원탈퇴',
+          color: theme.accent,
+          event: async () => {
+            if (
+              confirm(
+                '정말로 회원탈퇴를 진행하시겠습니까? 연결된 블로그도 함께 삭제됩니다.'
+              )
+            ) {
+              try {
+                await UserEndPoint.deleteUser();
+                window.localStorage.clear();
+                window.location.href = '/root';
+              } catch {
+                toast.error('회원탈퇴에 실패했습니다.');
+              }
+            }
+          },
         },
       ],
     },
@@ -84,6 +106,9 @@ export default function Setting() {
       contents: [
         {
           name: '고객지원',
+          event: () => {
+            navigate('/setting/support');
+          },
         },
       ],
     },

--- a/src/components/Setting/Support.tsx
+++ b/src/components/Setting/Support.tsx
@@ -1,0 +1,27 @@
+import * as S from './style';
+import { Header } from '../Layouts';
+import { toast } from 'react-toastify';
+import { Tooltip } from '../PopUp';
+
+export default function Support() {
+  const onClickCopyEmail = () => {
+    navigator.clipboard.writeText('honeymoa7069@gmail.com');
+    toast.success('이메일이 복사되었습니다!');
+  };
+
+  return (
+    <>
+      <Header.SettingHeader titleText="설정" />
+      <h2>고객지원</h2>
+      <S.SettingSupportWrapper>
+        <p>
+          사이트를 이용시 불편 사항은 아래 이메일로 문의해주시면 신속히
+          처리하겠습니다😭
+        </p>
+        <Tooltip message="클릭시 복사됩니다." direction="left">
+          <button onClick={onClickCopyEmail}>honeymoa7069@gmail.com</button>
+        </Tooltip>
+      </S.SettingSupportWrapper>
+    </>
+  );
+}

--- a/src/components/Setting/index.ts
+++ b/src/components/Setting/index.ts
@@ -1,1 +1,2 @@
-export { default as Setting } from './Setting';
+export { default as Main } from './Setting';
+export { default as Support } from './Support';

--- a/src/components/Setting/style.ts
+++ b/src/components/Setting/style.ts
@@ -47,3 +47,26 @@ export const SettingItemContent = styled.div<
   font-weight: 500;
   color: ${({ color, theme }) => color || theme.text.primary};
 `;
+
+export const SettingSupportWrapper = styled.div`
+  width: 100%;
+  margin-top: 48px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  button {
+    margin-top: 16px;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 8px;
+    background-color: ${({ theme }) => theme.button.secondary.base};
+    color: ${({ theme }) => theme.text.primary};
+    font-size: 16px;
+    font-weight: 500;
+    cursor: pointer;
+    &:hover {
+      background-color: ${({ theme }) => theme.button.secondary.hover};
+    }
+  }
+`;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,3 +3,4 @@ export * as PopUp from './PopUp';
 export * as Error from './Error';
 export * as Connection from './Connection';
 export * as Modal from './Modal';
+export * as Setting from './Setting';

--- a/src/provider/AppProvider.tsx
+++ b/src/provider/AppProvider.tsx
@@ -9,7 +9,15 @@ import { ToastContainer } from 'react-toastify';
 import { useState } from 'react';
 import * as Chat from '@/components/Chat';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5,
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  },
+});
 
 /**
  * 여러 Provider를 한번에 관리하는 컴포넌트

--- a/src/provider/AppProvider.tsx
+++ b/src/provider/AppProvider.tsx
@@ -12,7 +12,7 @@ import * as Chat from '@/components/Chat';
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 1000 * 60 * 5,
+      staleTime: Infinity,
       refetchOnWindowFocus: false,
       retry: false,
     },

--- a/src/routes/ValidationRoute.tsx
+++ b/src/routes/ValidationRoute.tsx
@@ -1,9 +1,8 @@
-import { Error } from '@/components';
+import { Error, Setting } from '@/components';
 import ChangePassword from '@/components/Auth/ChangePassword';
 import { Main } from '@/components/Main';
 import { Post } from '@/components/Blog/Post';
 import Root from '@/components/Root';
-import { Setting } from '@/components/Setting';
 import * as Chat from '@/components/Chat';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import AccessAuth from './AccessAuth';
@@ -66,7 +65,13 @@ const routesList: RouteListType[] = [
     id: 'route--setting',
     path: '/setting',
     private: true,
-    element: <Setting />,
+    element: <Setting.Main />,
+  },
+  {
+    id: 'route--setting-support',
+    path: '/setting/support',
+    private: false,
+    element: <Setting.Support />,
   },
   {
     id: 'route--chat',


### PR DESCRIPTION
## #️⃣연관된 이슈

> #103 

## 📝작업 내용

> 로그아웃

- 로그아웃시에는 따로 api요청은 없고, 토큰값만 스토리지에서 삭제할 수 있도록 만들었습니다.

> 회원 탈퇴

- 회원탈퇴시, 로그아웃과 동일하게 동작하는데, UX적으로 회원이 탈퇴된건지 명확하지가 않아서 나중에 수정해야 할 것 같습니다.

> 고객지원

- 현재는 단순히 이메일을 복제해서 넣을 수 있도록 만들었습니다.

> 토큰 있는 인스턴스 수정

- accessToken과 refreshToken이 비어있다면 계속해서 무한 요청을 보내는 버그가 있어서, instance에서 요청을 보내기 전에 토큰값이 없다면 에러를 반환하도록 수정했습니다.

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/affa566b-4496-4687-b9a3-1397ca39b6d7)
![image](https://github.com/user-attachments/assets/5037c569-740d-4f83-8bc5-54c2c5685d9f)


## 💬리뷰 요구사항(선택)

> 삭제시, `Mutation`을 호출하는게 아닌, `EndPoint`를 직접 호출합니다. 어짜피 한 번 일어나야 하는 동작이라 그렇게 구현했는데, 우선 `Mutation`로직을 만들어 놓긴 했습니다.

> 연결 검색 버그
@hobiJeong @NicoDora 
![image](https://github.com/user-attachments/assets/3a8b9973-6e89-4bf9-8415-0547eda2f683)
![image](https://github.com/user-attachments/assets/2d94bd3d-7488-442a-ba1f-908c132ac263)

회원 탈퇴를 해서 로그인은 진행되지 않지만, 검색에서는 뜨는 버그가 있는 것 같습니다. 확인 한 번 부탁드립니다.