### PR TITLE
블로그 리팩터링 및 기능 추가

### DIFF
--- a/src/components/Blog/BlogList/BlogListEachHoneyCard.tsx
+++ b/src/components/Blog/BlogList/BlogListEachHoneyCard.tsx
@@ -4,8 +4,11 @@ import { PaginationContents } from './type';
 import { date } from '@/utils';
 import { useMemo } from 'react';
 import Image from '@/components/Image';
+import useScrollTo from '@/hook/useScrollTo';
 
 export function BlogListEachHoneyCard(props: PaginationContents) {
+  const { saveToPosition } = useScrollTo({ key: 'blog-list-location' });
+
   const postDate = useMemo(
     () => date.getFormattingDate({ date: props.createdAt, formatType: '월일' }),
     [props.date]
@@ -16,7 +19,10 @@ export function BlogListEachHoneyCard(props: PaginationContents) {
   }, [props.thumbnailImageUrl]);
 
   return (
-    <S.BlogHoneyCardWrapper to={`/blog/${props.blogId}/post/${props.id}`}>
+    <S.BlogHoneyCardWrapper
+      to={`/blog/${props.blogId}/post/${props.id}`}
+      onClick={saveToPosition}
+    >
       {!isThumbnailImage ? (
         <>
           <S.HoneyInfoWrapper>

--- a/src/components/Blog/BlogList/BlogListEachHoneyCard.tsx
+++ b/src/components/Blog/BlogList/BlogListEachHoneyCard.tsx
@@ -7,7 +7,7 @@ import Image from '@/components/Image';
 import useScrollTo from '@/hook/useScrollTo';
 
 export function BlogListEachHoneyCard(props: PaginationContents) {
-  const { saveToPosition } = useScrollTo({ key: 'blog-list-location' });
+  const { saveToPosition } = useScrollTo();
 
   const postDate = useMemo(
     () => date.getFormattingDate({ date: props.createdAt, formatType: '월일' }),
@@ -21,7 +21,7 @@ export function BlogListEachHoneyCard(props: PaginationContents) {
   return (
     <S.BlogHoneyCardWrapper
       to={`/blog/${props.blogId}/post/${props.id}`}
-      onClick={saveToPosition}
+      onClick={() => saveToPosition(window.scrollX, window.scrollY)}
     >
       {!isThumbnailImage ? (
         <>

--- a/src/components/Blog/BlogList/PrivateBlogList.tsx
+++ b/src/components/Blog/BlogList/PrivateBlogList.tsx
@@ -6,9 +6,12 @@ import { Link } from 'react-router-dom';
 import useObserver from '@/hook/useObserver';
 import { useFilterPageStore } from '@/store/paginationStore/useFilterPageStore';
 import SelectBlogDateSection from './SelectBlogDateSection';
+import useScrollTo from '@/hook/useScrollTo';
 
 export default function PrivateBlogList({ id }: { id: string }) {
   const { year, month, filter } = useFilterPageStore();
+
+  useScrollTo({ key: 'blog-list-location' });
 
   const getBlogFilter = useMemo(
     () => ({

--- a/src/components/Blog/BlogList/PrivateBlogList.tsx
+++ b/src/components/Blog/BlogList/PrivateBlogList.tsx
@@ -1,23 +1,14 @@
-import { Svg } from '@/components/Svg';
 import * as S from './style';
 import { BlogListEachHoneyCard } from './BlogListEachHoneyCard';
-import { useTheme } from 'styled-components';
 import { useMemo } from 'react';
-import { date } from '@/utils';
 import { GetPrivateBlogPaginationQuery } from '@/apis/blog/queries';
 import { Link } from 'react-router-dom';
 import useObserver from '@/hook/useObserver';
 import { useFilterPageStore } from '@/store/paginationStore/useFilterPageStore';
-import {
-  onChangeYearHandler,
-  onClickYearPrevAndNextHandler,
-  onFilterHandler,
-} from './utils';
+import SelectBlogDateSection from './SelectBlogDateSection';
 
 export default function PrivateBlogList({ id }: { id: string }) {
-  const theme = useTheme();
-
-  const { year, month, filter, setMonth } = useFilterPageStore();
+  const { year, month, filter } = useFilterPageStore();
 
   const getBlogFilter = useMemo(
     () => ({
@@ -38,49 +29,7 @@ export default function PrivateBlogList({ id }: { id: string }) {
 
   return (
     <S.BlogListWrapper>
-      <S.BlogListHeaderWrapper>
-        <div>
-          <S.BlogListFilterSelect onChange={onFilterHandler} value={filter}>
-            <option value="all">전체</option>
-            <option value="public">공개글</option>
-          </S.BlogListFilterSelect>
-          <S.BlogSelectYearButtonWrapper>
-            <button onClick={() => onClickYearPrevAndNextHandler('prev')}>
-              <Svg.PrevIcon color={theme.text.primary} />
-            </button>
-            <span>
-              <input
-                type="date"
-                id="selectYear"
-                onChange={onChangeYearHandler}
-                placeholder={year}
-              />
-              년 의 달콤한 이야기
-            </span>
-            <button onClick={() => onClickYearPrevAndNextHandler('next')}>
-              <Svg.NextIcon color={theme.text.primary} />
-            </button>
-          </S.BlogSelectYearButtonWrapper>
-        </div>
-        <div>
-          {Array.from({ length: 12 }, (_, i) => (
-            <S.BlogSelectMonthButton
-              key={`${i + 1}-month-filter`}
-              $isSelectedMonth={
-                month ===
-                date.getFormattingDate({ date: i + 1, formatType: 'MM' })
-              }
-              onClick={() =>
-                setMonth(
-                  date.getFormattingDate({ date: i + 1, formatType: 'MM' })
-                )
-              }
-            >
-              {i + 1} 월
-            </S.BlogSelectMonthButton>
-          ))}
-        </div>
-      </S.BlogListHeaderWrapper>
+      <SelectBlogDateSection />
       <S.BlogSelectMonthSpan>{1}월</S.BlogSelectMonthSpan>
       {getBlogInfo?.data?.pages[0].contents.length !== 0 ? (
         <S.BlogListPaginationWrapper>

--- a/src/components/Blog/BlogList/PrivateBlogList.tsx
+++ b/src/components/Blog/BlogList/PrivateBlogList.tsx
@@ -11,7 +11,7 @@ import useScrollTo from '@/hook/useScrollTo';
 export default function PrivateBlogList({ id }: { id: string }) {
   const { year, month, filter } = useFilterPageStore();
 
-  useScrollTo({ key: 'blog-list-location' });
+  useScrollTo();
 
   const getBlogFilter = useMemo(
     () => ({

--- a/src/components/Blog/BlogList/PublicBlogList.tsx
+++ b/src/components/Blog/BlogList/PublicBlogList.tsx
@@ -5,10 +5,12 @@ import { Header, SideNavigate } from '@/components/Layouts';
 import { BlogListEachHoneyCard } from './BlogListEachHoneyCard';
 import { Link } from 'react-router-dom';
 import useObserver from '@/hook/useObserver';
+import useScrollTo from '@/hook/useScrollTo';
 
 export default function PublicBlogList() {
   const myInfo = UserQueries.GetMyInfoQuery();
   const getBlogInfo = BlogQueries.GetSingleBlogQuery(myInfo?.id);
+  useScrollTo({ key: 'blog-list-location' });
 
   const getPublicBlogList = BlogQueries.GetPublicBlogPaginationQuery({});
   const { obsRef } = useObserver({

--- a/src/components/Blog/BlogList/PublicBlogList.tsx
+++ b/src/components/Blog/BlogList/PublicBlogList.tsx
@@ -10,7 +10,7 @@ import useScrollTo from '@/hook/useScrollTo';
 export default function PublicBlogList() {
   const myInfo = UserQueries.GetMyInfoQuery();
   const getBlogInfo = BlogQueries.GetSingleBlogQuery(myInfo?.id);
-  useScrollTo({ key: 'blog-list-location' });
+  useScrollTo({});
 
   const getPublicBlogList = BlogQueries.GetPublicBlogPaginationQuery({});
   const { obsRef } = useObserver({

--- a/src/components/Blog/BlogList/SelectBlogDateSection.tsx
+++ b/src/components/Blog/BlogList/SelectBlogDateSection.tsx
@@ -1,0 +1,62 @@
+import { Svg } from '@/components/Svg';
+import * as S from './style';
+import { useTheme } from 'styled-components';
+import {
+  onChangeYearHandler,
+  onClickYearPrevAndNextHandler,
+  onFilterHandler,
+} from './utils';
+import { useFilterPageStore } from '@/store/paginationStore/useFilterPageStore';
+import { date } from '@/utils';
+
+export default function SelectBlogDateSection() {
+  const theme = useTheme();
+
+  const { year, month, filter, setMonth } = useFilterPageStore();
+
+  return (
+    <S.BlogListHeaderWrapper>
+      <div>
+        <S.BlogListFilterSelect onChange={onFilterHandler} value={filter}>
+          <option value="all">전체</option>
+          <option value="public">공개글</option>
+        </S.BlogListFilterSelect>
+        <S.BlogSelectYearButtonWrapper>
+          <button onClick={() => onClickYearPrevAndNextHandler('prev')}>
+            <Svg.PrevIcon color={theme.text.primary} />
+          </button>
+          <span>
+            <input
+              type="date"
+              id="selectYear"
+              onChange={onChangeYearHandler}
+              placeholder={year}
+            />
+            년 의 달콤한 이야기
+          </span>
+          <button onClick={() => onClickYearPrevAndNextHandler('next')}>
+            <Svg.NextIcon color={theme.text.primary} />
+          </button>
+        </S.BlogSelectYearButtonWrapper>
+      </div>
+      <div>
+        {Array.from({ length: 12 }, (_, i) => (
+          <S.BlogSelectMonthButton
+            key={`${i + 1}-month-filter`}
+            $isSelectedMonth={
+              month ===
+              date.getFormattingDate({ date: i + 1, formatType: 'MM' })
+            }
+            onClick={() =>
+              setMonth(
+                date.getFormattingDate({ date: i + 1, formatType: 'MM' })
+              )
+            }
+          >
+            {i + 1} 월
+          </S.BlogSelectMonthButton>
+        ))}
+      </div>
+    </S.BlogListHeaderWrapper>
+  );
+}

--- a/src/hook/useObserver.ts
+++ b/src/hook/useObserver.ts
@@ -14,7 +14,7 @@ export default function useObserver({ threshold = 0.1, event }: InfiniteProps) {
       const target = entries[0];
       if (target.isIntersecting && event) {
         //옵저버 중복 실행 방지
-        preventRef.current = false; //옵저버 중복 실행 방지
+        preventRef.current = false;
         event();
       }
     },

--- a/src/hook/useObserver.ts
+++ b/src/hook/useObserver.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 interface InfiniteProps {
   threshold?: number;
@@ -9,14 +9,17 @@ export default function useObserver({ threshold = 0.1, event }: InfiniteProps) {
   const obsRef = useRef<HTMLDivElement>(null);
   const preventRef = useRef(true); //옵저버 중복 방지
 
-  const handleObs: IntersectionObserverCallback = entries => {
-    const target = entries[0];
-    if (target.isIntersecting && event) {
-      //옵저버 중복 실행 방지
-      preventRef.current = false; //옵저버 중복 실행 방지
-      event();
-    }
-  };
+  const handleObs: IntersectionObserverCallback = useCallback(
+    entries => {
+      const target = entries[0];
+      if (target.isIntersecting && event) {
+        //옵저버 중복 실행 방지
+        preventRef.current = false; //옵저버 중복 실행 방지
+        event();
+      }
+    },
+    [event]
+  );
 
   //옵저버 생성
   useEffect(() => {
@@ -25,6 +28,7 @@ export default function useObserver({ threshold = 0.1, event }: InfiniteProps) {
     return () => {
       observer.disconnect();
     };
-  }, [obsRef]);
+  }, [handleObs, threshold]);
+
   return { obsRef };
 }

--- a/src/hook/useScrollTo.ts
+++ b/src/hook/useScrollTo.ts
@@ -1,27 +1,30 @@
-import { useLayoutEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import useSessionStorage from './useSessionStorage';
 
-interface useScrollToProps {
-  key: string;
+interface UseScrollToProps {
+  x?: number;
+  y?: number;
 }
 
-export default function useScrollTo({ key }: useScrollToProps) {
-  const { value, set } = useSessionStorage(key);
+export default function useScrollTo({ x = 0, y = 0 }: UseScrollToProps = {}) {
+  const { value, set } = useSessionStorage('__scroll_position_back');
 
-  const saveToPosition = () => {
-    const backState = JSON.stringify([window.scrollX, window.scrollY]);
-    set(backState);
-  };
+  const saveToPosition = useCallback(
+    (scrollX = window.scrollX, scrollY = window.scrollY) => {
+      set([scrollX, scrollY]);
+    },
+    [set]
+  );
 
-  useLayoutEffect(() => {
-    window.scrollTo(0, 0);
-
+  useEffect(() => {
     //이전 위치가 존재할 경우, 해당 위치로 이동
     if (value) {
-      const [x, y] = JSON.parse(value);
+      const [savedX, savedY] = JSON.parse(value);
+      window.scrollTo(savedX, savedY);
+    } else {
       window.scrollTo(x, y);
     }
-  }, []);
+  }, [value, x, y]);
 
   return { saveToPosition };
 }

--- a/src/hook/useScrollTo.ts
+++ b/src/hook/useScrollTo.ts
@@ -1,0 +1,27 @@
+import { useLayoutEffect } from 'react';
+import useSessionStorage from './useSessionStorage';
+
+interface useScrollToProps {
+  key: string;
+}
+
+export default function useScrollTo({ key }: useScrollToProps) {
+  const { value, set } = useSessionStorage(key);
+
+  const saveToPosition = () => {
+    const backState = JSON.stringify([window.scrollX, window.scrollY]);
+    set(backState);
+  };
+
+  useLayoutEffect(() => {
+    window.scrollTo(0, 0);
+
+    //이전 위치가 존재할 경우, 해당 위치로 이동
+    if (value) {
+      const [x, y] = JSON.parse(value);
+      window.scrollTo(x, y);
+    }
+  }, []);
+
+  return { saveToPosition };
+}

--- a/src/hook/useSessionStorage.ts
+++ b/src/hook/useSessionStorage.ts
@@ -1,0 +1,39 @@
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+import { toast } from 'react-toastify';
+
+export default function useSessionStorage(
+  key: string,
+  initialValue?: string | null
+) {
+  const getSnapshot = () => sessionStorage.getItem(key);
+
+  const subscribe = (listener: () => void) => {
+    window.addEventListener('storage', listener);
+    return () => window.removeEventListener('storage', listener);
+  };
+
+  const externalStoreState = useSyncExternalStore(subscribe, getSnapshot);
+
+  const store = useMemo(() => {
+    return externalStoreState ? externalStoreState : initialValue;
+  }, [externalStoreState, initialValue]);
+
+  const setStorage = useCallback(
+    (newValue: string) => {
+      try {
+        sessionStorage.setItem(key, newValue);
+        dispatchEvent(new StorageEvent('storage', { key: key, newValue }));
+      } catch (error) {
+        toast.error(`스토리지에 저장하는데 문제가 발생했습니다: ${error}`);
+      }
+    },
+    [key]
+  );
+
+  const removeStorage = useCallback(() => {
+    sessionStorage.removeItem(key);
+    dispatchEvent(new StorageEvent('storage', { key: key }));
+  }, [key]);
+
+  return { value: store, set: setStorage, remove: removeStorage };
+}

--- a/src/hook/useSessionStorage.ts
+++ b/src/hook/useSessionStorage.ts
@@ -19,10 +19,13 @@ export default function useSessionStorage(
   }, [externalStoreState, initialValue]);
 
   const setStorage = useCallback(
-    (newValue: string) => {
+    (newValue: unknown) => {
+      const parsedValue = JSON.stringify(newValue);
       try {
-        sessionStorage.setItem(key, newValue);
-        dispatchEvent(new StorageEvent('storage', { key: key, newValue }));
+        sessionStorage.setItem(key, parsedValue);
+        dispatchEvent(
+          new StorageEvent('storage', { key: key, newValue: parsedValue })
+        );
       } catch (error) {
         toast.error(`스토리지에 저장하는데 문제가 발생했습니다: ${error}`);
       }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #112 

## 📝작업 내용

> 블로그 컴포넌트 분리

- 하나의 컴포넌트에서 너무 복잡도가 높아질 것 같아서, blog중 header에서 날짜를 변경하는 부분을 컴포넌트로 분리하고, zustand를 활용해서 state를 관리했습니다.

> 뒤로가기 구현

`useScrollTo` hook을 구현했습니다. 원래는 `history API`를 사용해서 구현할까 했는데, 블로그 게시글 특성상, 새로고침 이후에도 값이 유지되어야 한다는 생각이 들어서, `session storage`를 활용해서 구현했습니다.

현재 `useSessionStorage`와 `useLocalStorage`의 로직이 100% 동일합니다. 그래서 하나의 `useStorage` 라는 이름의 `hook`으로 변경해서 관리할까 합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 내용

https://www.notion.so/1b729d6fc06d80f9a60afd17e454c0bd
해당 블로그에서 확인 가능
