### PR TITLE
채팅 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8701,6 +8701,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/immer": {
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -16406,6 +16418,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/src/apis/auth/queries.ts
+++ b/src/apis/auth/queries.ts
@@ -15,6 +15,9 @@ export const LoginQuery = () => {
       queryClient.invalidateQueries({
         queryKey: ['auth-sign-in'],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['chat-rooms', 'me'],
+      });
       setToken(data.accessToken);
       setRefreshToken(data.refreshToken);
       toast.success('로그인 성공');

--- a/src/apis/chat/endpoint.ts
+++ b/src/apis/chat/endpoint.ts
@@ -18,7 +18,7 @@ export async function getBelongToChatRoom(): Promise<BelongToMeChatRoomReturnTyp
 //채팅 조회
 export async function getChatRoomPagination({
   id,
-  limit = 20,
+  limit = 5,
   ...params
 }: PaginationBaseType): Promise<ChatMessagePaginationType> {
   const response = await instanceToken.get(`/chat-rooms/${id}/messages`, {

--- a/src/apis/chat/endpoint.ts
+++ b/src/apis/chat/endpoint.ts
@@ -18,7 +18,7 @@ export async function getBelongToChatRoom(): Promise<BelongToMeChatRoomReturnTyp
 //채팅 조회
 export async function getChatRoomPagination({
   id,
-  limit = 5,
+  limit = 20,
   ...params
 }: PaginationBaseType): Promise<ChatMessagePaginationType> {
   const response = await instanceToken.get(`/chat-rooms/${id}/messages`, {

--- a/src/apis/chat/queries.ts
+++ b/src/apis/chat/queries.ts
@@ -40,7 +40,7 @@ export function useGetBelongToChatRoom() {
 
 export const useChattingMessagePagination = (params: PaginationBaseType) => {
   const response = useInfiniteQuery({
-    queryKey: ['chat-rooms', params.id, 'messages'],
+    queryKey: ['chat-rooms', 'messages'],
     queryFn: ({ pageParam }: { pageParam?: string }) =>
       ChatEndPoint.getChatRoomPagination({
         cursor: pageParam ? JSON.stringify([`id:${pageParam}`]) : undefined,

--- a/src/components/Chat/ChatBox/ChatModal.tsx
+++ b/src/components/Chat/ChatBox/ChatModal.tsx
@@ -3,20 +3,15 @@ import { Link } from 'react-router-dom';
 import { Svg } from '@/components/Svg';
 import { ChatQueries } from '@/apis/chat';
 import { toast } from 'react-toastify';
-import {
-  ChatCurrentDataType,
-  ChatMessageListType,
-  ChatModalProps,
-  ChatServerBaseResponse,
-} from './type';
+import { ChatModalProps } from './type';
 import { BlogQueries } from '@/apis/blog';
 import { UserQueries } from '@/apis/user';
 import { Profile } from '@/components/Layouts';
 import { useChattingMessagePagination } from '@/apis/chat/queries';
-import useObserver from '@/hook/useObserver';
 import { changeInfo, date } from '@/utils';
-import { useEffect, useRef, useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import { useReceivedMessage, useScrollToBottom } from '../hooks';
+import useObserver from '@/hook/useObserver';
 
 export default function ChatRoomModal({
   setIsOpen,
@@ -26,7 +21,6 @@ export default function ChatRoomModal({
   const createChatRoom = ChatQueries.usePostCreateChatRoom();
   const myInfo = UserQueries.GetMyInfoQuery();
   const blogInfo = BlogQueries.GetSingleBlogQuery(myInfo?.id);
-  const messageRef = useRef<HTMLDivElement>(null);
 
   const [chatInfo, setChatInfo] = useState({
     message: '',
@@ -40,92 +34,32 @@ export default function ChatRoomModal({
     });
   };
 
+  //타입 가드
+  const isString = (value: unknown): value is string => {
+    return typeof value === 'string';
+  };
   const messages = useChattingMessagePagination({
     id: isString(belongToChatRoomData?.id) ? belongToChatRoomData.id : '',
     orderBy: JSON.stringify(['createdAt:desc']),
   });
 
-  //타입 가드
-  function isString(value: unknown): value is string {
-    return typeof value === 'string';
-  }
-  const messagesContents = messages?.data?.pages.flatMap(page => page.contents);
+  const messagesContents = useMemo(() => {
+    return messages?.data?.pages.flatMap(page => page.contents) || [];
+  }, [messages?.data?.pages]);
 
   const { obsRef } = useObserver({
-    event: async () => {
-      await messages?.fetchNextPage();
+    event: () => {
+      messages?.fetchNextPage();
     },
     threshold: 0.1,
   });
-
-  const scrollToBottom = () => {
-    if (messageRef.current) {
-      messageRef.current.scrollTop = messageRef.current.scrollHeight;
-    }
-  };
-
-  useEffect(() => {
-    scrollToBottom();
-  }, [messages]);
-
-  const queryClient = useQueryClient();
-
-  const transformPaginatedData = (oldData: ChatCurrentDataType) => {
-    console.log(oldData);
-    if (!oldData) return oldData;
-
-    return {
-      ...oldData,
-      pages: oldData.pages.map(page => ({
-        totalCount: page.totalCount,
-        limit: page.limit,
-        contents: page.contents,
-        nextCursor: page.nextCursor,
-      })),
-    };
-  };
-
-  const onMessageReceived = (data: ChatMessageListType) => {
-    queryClient.setQueryData(
-      ['chat-rooms', belongToChatRoomData?.id, 'messages'],
-      (oldData: ChatCurrentDataType) => {
-        const transformedData = transformPaginatedData(oldData);
-        if (!oldData) return oldData;
-        return {
-          ...transformedData,
-          pages: transformedData.pages.map((page, index) => {
-            if (index === 0) {
-              return {
-                ...page,
-                contents: [
-                  {
-                    id: null,
-                    createdAt: new Date().toISOString(),
-                    updatedAt: new Date().toISOString(),
-                    roomId: data.roomId,
-                    senderId: data.senderId,
-                    message: data.message,
-                    blogPostUrl: '',
-                  },
-                  ...page.contents,
-                ],
-              };
-            }
-            return page;
-          }),
-        };
-      }
-    );
-  };
+  const { onMessageReceived } = useReceivedMessage();
+  const { scrollToBottomRef } = useScrollToBottom({
+    dependencies: [onMessageReceived],
+    isLoadingPastData: messages?.isFetchingNextPage,
+  });
 
   const onChangeMessage = changeInfo.text({ setState: setChatInfo });
-
-  useEffect(() => {
-    socket?.on('receive_message', onMessageReceived);
-    return () => {
-      socket?.off('receive_message', onMessageReceived);
-    };
-  }, [socket]);
 
   const sendMessageToServer: React.FormEventHandler<HTMLFormElement> = e => {
     e.preventDefault();
@@ -135,39 +69,7 @@ export default function ChatRoomModal({
         roomId: belongToChatRoomData?.id,
         message: chatInfo.message,
       },
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      (res: Partial<ChatServerBaseResponse>) => {
-        queryClient.setQueryData(
-          ['chat-rooms', belongToChatRoomData?.id, 'messages'],
-          (oldData: ChatCurrentDataType) => {
-            const transformedData = transformPaginatedData(oldData);
-            if (!oldData) return oldData;
-            return {
-              ...transformedData,
-              pages: transformedData.pages.map((page, index) => {
-                if (index === 0) {
-                  return {
-                    ...page,
-                    contents: [
-                      {
-                        id: null,
-                        createdAt: new Date().toISOString(),
-                        updatedAt: new Date().toISOString(),
-                        roomId: belongToChatRoomData?.id,
-                        senderId: myInfo?.id,
-                        message: chatInfo.message,
-                        blogPostUrl: '',
-                      },
-                      ...page.contents,
-                    ],
-                  };
-                }
-                return page;
-              }),
-            };
-          }
-        );
-      }
+      onMessageReceived
     );
     setChatInfo({ message: '' });
   };
@@ -197,12 +99,8 @@ export default function ChatRoomModal({
           </S.IconWrapper>
         </S.ChatControl>
       </S.ChatHeader>
-      <S.ChatBody ref={messageRef}>
-        {messages?.isPending ? (
-          <div>로딩중...</div>
-        ) : (
-          <S.ObserverBox ref={obsRef}></S.ObserverBox>
-        )}
+      <S.ChatBody ref={scrollToBottomRef}>
+        <S.ObserverBox ref={obsRef} />
         {messagesContents?.reverse().map(message => {
           const isOwner = message.senderId === myInfo?.id;
           return (

--- a/src/components/Chat/ChatBox/ChatModal.tsx
+++ b/src/components/Chat/ChatBox/ChatModal.tsx
@@ -3,7 +3,12 @@ import { Link } from 'react-router-dom';
 import { Svg } from '@/components/Svg';
 import { ChatQueries } from '@/apis/chat';
 import { toast } from 'react-toastify';
-import { ChatModalProps, ChatServerBaseResponse } from './type';
+import {
+  ChatCurrentDataType,
+  ChatMessageListType,
+  ChatModalProps,
+  ChatServerBaseResponse,
+} from './type';
 import { BlogQueries } from '@/apis/blog';
 import { UserQueries } from '@/apis/user';
 import { Profile } from '@/components/Layouts';
@@ -47,8 +52,8 @@ export default function ChatRoomModal({
   const messagesContents = messages?.data?.pages.flatMap(page => page.contents);
 
   const { obsRef } = useObserver({
-    event: () => {
-      messages?.fetchNextPage();
+    event: async () => {
+      await messages?.fetchNextPage();
     },
     threshold: 0.1,
   });
@@ -62,9 +67,11 @@ export default function ChatRoomModal({
   useEffect(() => {
     scrollToBottom();
   }, [messages]);
+
   const queryClient = useQueryClient();
 
-  const transformPaginatedData = oldData => {
+  const transformPaginatedData = (oldData: ChatCurrentDataType) => {
+    console.log(oldData);
     if (!oldData) return oldData;
 
     return {
@@ -78,10 +85,10 @@ export default function ChatRoomModal({
     };
   };
 
-  const onMessageReceived = (data: string) => {
+  const onMessageReceived = (data: ChatMessageListType) => {
     queryClient.setQueryData(
       ['chat-rooms', belongToChatRoomData?.id, 'messages'],
-      oldData => {
+      (oldData: ChatCurrentDataType) => {
         const transformedData = transformPaginatedData(oldData);
         if (!oldData) return oldData;
         return {
@@ -92,7 +99,7 @@ export default function ChatRoomModal({
                 ...page,
                 contents: [
                   {
-                    id: 'new',
+                    id: null,
                     createdAt: new Date().toISOString(),
                     updatedAt: new Date().toISOString(),
                     roomId: data.roomId,
@@ -128,10 +135,11 @@ export default function ChatRoomModal({
         roomId: belongToChatRoomData?.id,
         message: chatInfo.message,
       },
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       (res: Partial<ChatServerBaseResponse>) => {
         queryClient.setQueryData(
           ['chat-rooms', belongToChatRoomData?.id, 'messages'],
-          oldData => {
+          (oldData: ChatCurrentDataType) => {
             const transformedData = transformPaginatedData(oldData);
             if (!oldData) return oldData;
             return {
@@ -142,7 +150,7 @@ export default function ChatRoomModal({
                     ...page,
                     contents: [
                       {
-                        id: 'new',
+                        id: null,
                         createdAt: new Date().toISOString(),
                         updatedAt: new Date().toISOString(),
                         roomId: belongToChatRoomData?.id,
@@ -193,7 +201,7 @@ export default function ChatRoomModal({
         {messages?.isPending ? (
           <div>로딩중...</div>
         ) : (
-          <S.ObserverBox></S.ObserverBox>
+          <S.ObserverBox ref={obsRef}></S.ObserverBox>
         )}
         {messagesContents?.reverse().map(message => {
           const isOwner = message.senderId === myInfo?.id;
@@ -241,6 +249,7 @@ export default function ChatRoomModal({
             id="message"
             onChange={onChangeMessage}
             value={chatInfo.message}
+            autoComplete="off"
           />
           <S.SendIconButton type="submit">
             <Svg.SendIcon />

--- a/src/components/Chat/ChatBox/ChatModal.tsx
+++ b/src/components/Chat/ChatBox/ChatModal.tsx
@@ -3,24 +3,27 @@ import { Link } from 'react-router-dom';
 import { Svg } from '@/components/Svg';
 import { ChatQueries } from '@/apis/chat';
 import { toast } from 'react-toastify';
-import { ChatModalProps } from './type';
+import { ChatAckResponse, ChatModalProps } from './type';
 import { BlogQueries } from '@/apis/blog';
 import { UserQueries } from '@/apis/user';
 import { Profile } from '@/components/Layouts';
 import { useChattingMessagePagination } from '@/apis/chat/queries';
 import { changeInfo, date } from '@/utils';
-import { useMemo, useState } from 'react';
-import { useReceivedMessage, useScrollToBottom } from '../hooks';
+import { useEffect, useMemo, useState } from 'react';
+import { scrollToBottom, useReceivedMessage } from '../hooks';
 import useObserver from '@/hook/useObserver';
 
 export default function ChatRoomModal({
   setIsOpen,
   belongToChatRoomData,
   socket,
+  scrollToBottomRef,
 }: ChatModalProps) {
   const createChatRoom = ChatQueries.usePostCreateChatRoom();
   const myInfo = UserQueries.GetMyInfoQuery();
   const blogInfo = BlogQueries.GetSingleBlogQuery(myInfo?.id);
+
+  const [isAtBottom, setIsAtBottom] = useState(true); // 스크롤이 하단에 있는지 추적
 
   const [chatInfo, setChatInfo] = useState({
     message: '',
@@ -48,18 +51,55 @@ export default function ChatRoomModal({
   }, [messages?.data?.pages]);
 
   const { obsRef } = useObserver({
-    event: () => {
-      messages?.fetchNextPage();
+    event: async () => {
+      if (!messages?.data?.pages.length) return;
+
+      const lastPage = messages.data.pages[messages.data.pages.length - 1];
+
+      if (lastPage.nextCursor !== null) {
+        const prevHeight = scrollToBottomRef.current?.scrollHeight || 0;
+
+        await messages.fetchNextPage();
+
+        setTimeout(() => {
+          if (scrollToBottomRef.current) {
+            const newHeight = scrollToBottomRef.current.scrollHeight;
+            scrollToBottomRef.current.scrollTop += newHeight - prevHeight;
+          }
+        }, 0);
+      }
     },
     threshold: 0.1,
   });
   const { onMessageReceived } = useReceivedMessage();
-  const { scrollToBottomRef } = useScrollToBottom({
-    dependencies: [onMessageReceived],
-    isLoadingPastData: messages?.isFetchingNextPage,
-  });
 
-  const onChangeMessage = changeInfo.text({ setState: setChatInfo });
+  // 스크롤 위치 체크
+  useEffect(() => {
+    const handleScroll = () => {
+      const chatBody = scrollToBottomRef.current;
+      if (chatBody) {
+        const { scrollTop, scrollHeight, clientHeight } = chatBody;
+        setIsAtBottom(scrollTop + clientHeight >= scrollHeight - 10);
+      }
+    };
+
+    const chatBody = scrollToBottomRef.current;
+    if (chatBody) {
+      chatBody.addEventListener('scroll', handleScroll);
+    }
+    return () => {
+      if (chatBody) {
+        chatBody.removeEventListener('scroll', handleScroll);
+      }
+    };
+  }, []);
+
+  // 처음 로드 시와 새 메시지 수신 시 스크롤 제어
+  useEffect(() => {
+    if (isAtBottom) {
+      scrollToBottom(scrollToBottomRef);
+    }
+  }, [messagesContents, isAtBottom]);
 
   const sendMessageToServer: React.FormEventHandler<HTMLFormElement> = e => {
     e.preventDefault();
@@ -69,10 +109,16 @@ export default function ChatRoomModal({
         roomId: belongToChatRoomData?.id,
         message: chatInfo.message,
       },
-      onMessageReceived
+      (res: ChatAckResponse) => {
+        setIsAtBottom(true);
+        scrollToBottom(scrollToBottomRef);
+        onMessageReceived(res.sentMessage);
+      }
     );
     setChatInfo({ message: '' });
   };
+
+  const onChangeMessage = changeInfo.text({ setState: setChatInfo });
 
   if (belongToChatRoomData === undefined)
     return (

--- a/src/components/Chat/ChatBox/ChatModal.tsx
+++ b/src/components/Chat/ChatBox/ChatModal.tsx
@@ -3,23 +3,25 @@ import { Link } from 'react-router-dom';
 import { Svg } from '@/components/Svg';
 import { ChatQueries } from '@/apis/chat';
 import { toast } from 'react-toastify';
-import { ChatModalProps } from './type';
+import { ChatModalProps, ChatServerBaseResponse } from './type';
 import { BlogQueries } from '@/apis/blog';
 import { UserQueries } from '@/apis/user';
 import { Profile } from '@/components/Layouts';
 import { useChattingMessagePagination } from '@/apis/chat/queries';
 import useObserver from '@/hook/useObserver';
 import { changeInfo, date } from '@/utils';
-import { useEffect, useState } from 'react';
-import { useSocket } from '@/hook/useSocket';
+import { useEffect, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 export default function ChatRoomModal({
   setIsOpen,
   belongToChatRoomData,
+  socket,
 }: ChatModalProps) {
   const createChatRoom = ChatQueries.usePostCreateChatRoom();
   const myInfo = UserQueries.GetMyInfoQuery();
   const blogInfo = BlogQueries.GetSingleBlogQuery(myInfo?.id);
+  const messageRef = useRef<HTMLDivElement>(null);
 
   const [chatInfo, setChatInfo] = useState({
     message: '',
@@ -42,7 +44,6 @@ export default function ChatRoomModal({
   function isString(value: unknown): value is string {
     return typeof value === 'string';
   }
-
   const messagesContents = messages?.data?.pages.flatMap(page => page.contents);
 
   const { obsRef } = useObserver({
@@ -52,30 +53,116 @@ export default function ChatRoomModal({
     threshold: 0.1,
   });
 
-  const onChangeMessage = changeInfo.text({ setState: setChatInfo });
-
-  const socket = useSocket();
-
-  const onMessageReceived = (data: string) => {
-    console.log(data);
-  };
-
-  const sendMessageToServer = () => {
-    socket?.emit('send_message', {
-      roomId: belongToChatRoomData?.id,
-      message: chatInfo.message,
-    });
-    setChatInfo({ message: '' });
+  const scrollToBottom = () => {
+    if (messageRef.current) {
+      messageRef.current.scrollTop = messageRef.current.scrollHeight;
+    }
   };
 
   useEffect(() => {
-    socket?.emit('enter_chat_room', { roomId: belongToChatRoomData?.id });
+    scrollToBottom();
+  }, [messages]);
+  const queryClient = useQueryClient();
+
+  const transformPaginatedData = oldData => {
+    if (!oldData) return oldData;
+
+    return {
+      ...oldData,
+      pages: oldData.pages.map(page => ({
+        totalCount: page.totalCount,
+        limit: page.limit,
+        contents: page.contents,
+        nextCursor: page.nextCursor,
+      })),
+    };
+  };
+
+  const onMessageReceived = (data: string) => {
+    queryClient.setQueryData(
+      ['chat-rooms', belongToChatRoomData?.id, 'messages'],
+      oldData => {
+        const transformedData = transformPaginatedData(oldData);
+        if (!oldData) return oldData;
+        return {
+          ...transformedData,
+          pages: transformedData.pages.map((page, index) => {
+            if (index === 0) {
+              return {
+                ...page,
+                contents: [
+                  {
+                    id: 'new',
+                    createdAt: new Date().toISOString(),
+                    updatedAt: new Date().toISOString(),
+                    roomId: data.roomId,
+                    senderId: data.senderId,
+                    message: data.message,
+                    blogPostUrl: '',
+                  },
+                  ...page.contents,
+                ],
+              };
+            }
+            return page;
+          }),
+        };
+      }
+    );
+  };
+
+  const onChangeMessage = changeInfo.text({ setState: setChatInfo });
+
+  useEffect(() => {
     socket?.on('receive_message', onMessageReceived);
     return () => {
-      socket?.off('enter_chat_room');
       socket?.off('receive_message', onMessageReceived);
     };
   }, [socket]);
+
+  const sendMessageToServer: React.FormEventHandler<HTMLFormElement> = e => {
+    e.preventDefault();
+    socket?.emit(
+      'send_message',
+      {
+        roomId: belongToChatRoomData?.id,
+        message: chatInfo.message,
+      },
+      (res: Partial<ChatServerBaseResponse>) => {
+        queryClient.setQueryData(
+          ['chat-rooms', belongToChatRoomData?.id, 'messages'],
+          oldData => {
+            const transformedData = transformPaginatedData(oldData);
+            if (!oldData) return oldData;
+            return {
+              ...transformedData,
+              pages: transformedData.pages.map((page, index) => {
+                if (index === 0) {
+                  return {
+                    ...page,
+                    contents: [
+                      {
+                        id: 'new',
+                        createdAt: new Date().toISOString(),
+                        updatedAt: new Date().toISOString(),
+                        roomId: belongToChatRoomData?.id,
+                        senderId: myInfo?.id,
+                        message: chatInfo.message,
+                        blogPostUrl: '',
+                      },
+                      ...page.contents,
+                    ],
+                  };
+                }
+                return page;
+              }),
+            };
+          }
+        );
+      }
+    );
+    setChatInfo({ message: '' });
+  };
 
   if (belongToChatRoomData === undefined)
     return (
@@ -102,11 +189,11 @@ export default function ChatRoomModal({
           </S.IconWrapper>
         </S.ChatControl>
       </S.ChatHeader>
-      <S.ChatBody>
+      <S.ChatBody ref={messageRef}>
         {messages?.isPending ? (
           <div>로딩중...</div>
         ) : (
-          <S.ObserverBox ref={obsRef}></S.ObserverBox>
+          <S.ObserverBox></S.ObserverBox>
         )}
         {messagesContents?.reverse().map(message => {
           const isOwner = message.senderId === myInfo?.id;
@@ -148,14 +235,14 @@ export default function ChatRoomModal({
             <Svg.EmojiIcon />
           </S.IconWrapper>
         </S.FormAttachBox>
-        <S.ChatForm>
+        <S.ChatForm onSubmit={sendMessageToServer}>
           <S.ChatInput
             placeholder="메시지를 입력하세요..."
             id="message"
             onChange={onChangeMessage}
             value={chatInfo.message}
           />
-          <S.SendIconButton onClick={sendMessageToServer} type="button">
+          <S.SendIconButton type="submit">
             <Svg.SendIcon />
           </S.SendIconButton>
         </S.ChatForm>

--- a/src/components/Chat/ChatBox/ChatModal.tsx
+++ b/src/components/Chat/ChatBox/ChatModal.tsx
@@ -11,8 +11,7 @@ import { useChattingMessagePagination } from '@/apis/chat/queries';
 import useObserver from '@/hook/useObserver';
 import { changeInfo, date } from '@/utils';
 import { useEffect, useState } from 'react';
-import { io, Socket } from 'socket.io-client';
-import useLocalStorage from '@/hook/useLocalStorage';
+import { useSocket } from '@/hook/useSocket';
 
 export default function ChatRoomModal({
   setIsOpen,
@@ -55,52 +54,25 @@ export default function ChatRoomModal({
 
   const onChangeMessage = changeInfo.text({ setState: setChatInfo });
 
-  const [socket, setSocket] = useState<Socket | null>(null);
-  const { value: token } = useLocalStorage('accessToken');
-  const SOCKET_SERVER_URL = import.meta.env.VITE_SOCKET_SERVER_URL;
-
-  const connectedSocketServer = () => {
-    const _socket = io(`${SOCKET_SERVER_URL}`, {
-      autoConnect: false,
-      extraHeaders: {
-        authorization: `Bearer ${token}`,
-      },
-    });
-    _socket.connect();
-    setSocket(_socket);
-  };
+  const socket = useSocket();
 
   const onMessageReceived = (data: string) => {
     console.log(data);
   };
 
   const sendMessageToServer = () => {
-    console.log(`send message: ${chatInfo.message}`);
-    socket?.emit(
-      'send_message',
-      {
-        chatRoomId: belongToChatRoomData?.id,
-        message: chatInfo.message,
-      },
-      (res: string) => {
-        console.log(res);
-      }
-    );
+    socket?.emit('send_message', {
+      roomId: belongToChatRoomData?.id,
+      message: chatInfo.message,
+    });
     setChatInfo({ message: '' });
   };
 
   useEffect(() => {
-    socket?.emit(
-      'enter_chat_room',
-      {
-        roomId: belongToChatRoomData?.id,
-      },
-      (res: string) => {
-        console.log(res);
-      }
-    );
+    socket?.emit('enter_chat_room', { roomId: belongToChatRoomData?.id });
     socket?.on('receive_message', onMessageReceived);
     return () => {
+      socket?.off('enter_chat_room');
       socket?.off('receive_message', onMessageReceived);
     };
   }, [socket]);
@@ -115,7 +87,6 @@ export default function ChatRoomModal({
   return (
     <S.ChatBox>
       <S.ChatHeader>
-        <button onClick={connectedSocketServer}>접속</button>
         <S.ChatInfo>
           <Profile.TogetherImage members={blogInfo?.members} width="32px" />
           <span></span>

--- a/src/components/Chat/ChatBox/index.tsx
+++ b/src/components/Chat/ChatBox/index.tsx
@@ -4,10 +4,21 @@ import { Svg } from '@/components/Svg';
 import useLocalStorage from '@/hook/useLocalStorage';
 import ChatRoomModal from './ChatModal';
 import { ChatQueries } from '@/apis/chat';
+import { useSocket } from '@/hook/useSocket';
+import { useEffect } from 'react';
 
 export default function ChatBox({ isOpen, setIsOpen }: ChatBoxProps) {
   const { value: token } = useLocalStorage('accessToken');
   const belongToChatRoom = ChatQueries.useGetBelongToChatRoom();
+
+  const socket = useSocket();
+
+  useEffect(() => {
+    socket?.emit('enter_chat_room', { roomId: belongToChatRoom?.id });
+    return () => {
+      socket?.off('enter_chat_room');
+    };
+  }, [socket]);
 
   if (!token) return;
 
@@ -20,6 +31,7 @@ export default function ChatBox({ isOpen, setIsOpen }: ChatBoxProps) {
         <ChatRoomModal
           setIsOpen={setIsOpen}
           belongToChatRoomData={belongToChatRoom}
+          socket={socket}
         />
       )}
     </>

--- a/src/components/Chat/ChatBox/index.tsx
+++ b/src/components/Chat/ChatBox/index.tsx
@@ -5,8 +5,8 @@ import useLocalStorage from '@/hook/useLocalStorage';
 import ChatRoomModal from './ChatModal';
 import { ChatQueries } from '@/apis/chat';
 import { useSocket } from '@/hook/useSocket';
-import { useEffect } from 'react';
-import { useReceivedMessage } from '../hooks';
+import { useEffect, useRef } from 'react';
+import { scrollToBottom, useReceivedMessage } from '../hooks';
 
 export default function ChatBox({ isOpen, setIsOpen }: ChatBoxProps) {
   const { value: token } = useLocalStorage('accessToken');
@@ -15,21 +15,39 @@ export default function ChatBox({ isOpen, setIsOpen }: ChatBoxProps) {
   const socket = useSocket();
   const { onMessageReceived } = useReceivedMessage();
 
+  const scrollToBottomRef = useRef<HTMLDivElement>(null);
+
+  const openChatModalHandler = () => {
+    setIsOpen(prev => !prev);
+  };
+
   useEffect(() => {
     socket?.emit('enter_chat_room', { roomId: belongToChatRoom?.id });
-    socket?.on('receive_message', onMessageReceived);
+    socket?.on('receive_message', res => {
+      onMessageReceived(res);
+      scrollToBottom(scrollToBottomRef);
+    });
 
     return () => {
       socket?.off('enter_chat_room');
-      socket?.off('receive_message', onMessageReceived);
+      socket?.off('receive_message', res => {
+        onMessageReceived(res);
+        scrollToBottom(scrollToBottomRef);
+      });
     };
   }, [socket]);
+
+  useEffect(() => {
+    if (isOpen) {
+      scrollToBottom(scrollToBottomRef);
+    }
+  }, [isOpen]);
 
   if (!token) return;
 
   return (
     <>
-      <S.ButtonWrapper onClick={() => setIsOpen(prev => !prev)}>
+      <S.ButtonWrapper onClick={openChatModalHandler}>
         <Svg.ChatIcon size={40} />
       </S.ButtonWrapper>
       {isOpen && (
@@ -37,6 +55,7 @@ export default function ChatBox({ isOpen, setIsOpen }: ChatBoxProps) {
           setIsOpen={setIsOpen}
           belongToChatRoomData={belongToChatRoom}
           socket={socket}
+          scrollToBottomRef={scrollToBottomRef}
         />
       )}
     </>

--- a/src/components/Chat/ChatBox/index.tsx
+++ b/src/components/Chat/ChatBox/index.tsx
@@ -6,17 +6,22 @@ import ChatRoomModal from './ChatModal';
 import { ChatQueries } from '@/apis/chat';
 import { useSocket } from '@/hook/useSocket';
 import { useEffect } from 'react';
+import { useReceivedMessage } from '../hooks';
 
 export default function ChatBox({ isOpen, setIsOpen }: ChatBoxProps) {
   const { value: token } = useLocalStorage('accessToken');
   const belongToChatRoom = ChatQueries.useGetBelongToChatRoom();
 
   const socket = useSocket();
+  const { onMessageReceived } = useReceivedMessage();
 
   useEffect(() => {
     socket?.emit('enter_chat_room', { roomId: belongToChatRoom?.id });
+    socket?.on('receive_message', onMessageReceived);
+
     return () => {
       socket?.off('enter_chat_room');
+      socket?.off('receive_message', onMessageReceived);
     };
   }, [socket]);
 

--- a/src/components/Chat/ChatBox/style.ts
+++ b/src/components/Chat/ChatBox/style.ts
@@ -83,7 +83,7 @@ export const FormAttachBox = styled.div`
   display: flex;
 `;
 
-export const ChatForm = styled.div`
+export const ChatForm = styled.form`
   display: flex;
   margin: 3px;
 `;

--- a/src/components/Chat/ChatBox/style.ts
+++ b/src/components/Chat/ChatBox/style.ts
@@ -164,5 +164,4 @@ export const ChatContentsWrapper = styled.div<{ $isOwner?: boolean }>`
 
 export const ObserverBox = styled.div`
   width: 100%;
-  margin-bottom: 24px;
 `;

--- a/src/components/Chat/ChatBox/type.d.ts
+++ b/src/components/Chat/ChatBox/type.d.ts
@@ -8,6 +8,7 @@ export interface ChatModalProps {
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   belongToChatRoomData: BelongToMeChatRoomReturnType | undefined;
   socket: Socket | null;
+  scrollToBottomRef: React.RefObject<HTMLDivElement>;
 }
 
 export interface ChatMessageListType {
@@ -17,7 +18,7 @@ export interface ChatMessageListType {
   roomId: string;
   senderId: string;
   message: string;
-  blogPostUrl: string;
+  blogPostUrl: string | null;
 }
 
 export interface ChatServerBaseResponse {
@@ -29,4 +30,9 @@ export interface ChatServerBaseResponse {
 export interface ChatCurrentDataType {
   pageParam: Array;
   pages: ChatMessagePaginationType[];
+}
+
+export interface ChatAckResponse {
+  statusMessage: string;
+  sentMessage: ChatMessageListType;
 }

--- a/src/components/Chat/ChatBox/type.d.ts
+++ b/src/components/Chat/ChatBox/type.d.ts
@@ -1,6 +1,24 @@
 import { BelongToMeChatRoomReturnType } from '@/apis/chat/type';
+import { Socket } from 'socket.io-client';
 
 export interface ChatModalProps {
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   belongToChatRoomData: BelongToMeChatRoomReturnType | undefined;
+  socket: Socket | null;
+}
+
+export interface ChatMessageListType {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  roomId: string;
+  senderId: string;
+  message: string;
+  blogPostUrl: string;
+}
+
+export interface ChatServerBaseResponse {
+  message: string;
+  roomId: string;
+  blogPostUrl: string;
 }

--- a/src/components/Chat/ChatBox/type.d.ts
+++ b/src/components/Chat/ChatBox/type.d.ts
@@ -1,4 +1,7 @@
-import { BelongToMeChatRoomReturnType } from '@/apis/chat/type';
+import {
+  BelongToMeChatRoomReturnType,
+  ChatMessagePaginationType,
+} from '@/apis/chat/type';
 import { Socket } from 'socket.io-client';
 
 export interface ChatModalProps {
@@ -21,4 +24,9 @@ export interface ChatServerBaseResponse {
   message: string;
   roomId: string;
   blogPostUrl: string;
+}
+
+export interface ChatCurrentDataType {
+  pageParam: Array;
+  pages: ChatMessagePaginationType[];
 }

--- a/src/components/Chat/hooks.ts
+++ b/src/components/Chat/hooks.ts
@@ -1,0 +1,110 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { ChatCurrentDataType, ChatMessageListType } from './ChatBox/type';
+import { useEffect, useRef } from 'react';
+
+export const useReceivedMessage = () => {
+  const queryClient = useQueryClient();
+
+  const transformPaginatedData = (oldData: ChatCurrentDataType) => {
+    if (!oldData) return oldData;
+
+    return {
+      ...oldData,
+      pages: oldData.pages.map(page => ({
+        totalCount: page.totalCount,
+        limit: page.limit,
+        contents: page.contents,
+        nextCursor: page.nextCursor,
+      })),
+    };
+  };
+
+  const onMessageReceived = (data: ChatMessageListType) => {
+    queryClient.setQueryData(
+      ['chat-rooms', 'messages'],
+      (oldData: ChatCurrentDataType) => {
+        const transformedData = transformPaginatedData(oldData);
+        if (!oldData) return oldData;
+        return {
+          ...transformedData,
+          pages: transformedData.pages.map((page, index) => {
+            if (index === 0) {
+              return {
+                ...page,
+                contents: [
+                  {
+                    id: data.id,
+                    createdAt: data.createdAt,
+                    updatedAt: data.updatedAt,
+                    roomId: data.roomId,
+                    senderId: data.senderId,
+                    message: data.message,
+                    blogPostUrl: data.blogPostUrl,
+                  },
+                  ...page.contents,
+                ],
+              };
+            }
+            return page;
+          }),
+        };
+      }
+    );
+  };
+
+  return { onMessageReceived };
+};
+
+interface UseScrollToBottomParams {
+  dependencies?: unknown[];
+  isLoadingPastData?: boolean; // 과거 데이터 로드 여부
+}
+
+export const useScrollToBottom = ({
+  dependencies,
+  isLoadingPastData = false,
+}: UseScrollToBottomParams) => {
+  const scrollToBottomRef = useRef<HTMLDivElement>(null);
+
+  const scrollToBottom = () => {
+    if (scrollToBottomRef.current) {
+      scrollToBottomRef.current.scrollTop =
+        scrollToBottomRef.current.scrollHeight;
+    }
+  };
+
+  const maintainScrollPosition = () => {
+    const chatBody = scrollToBottomRef.current;
+    if (!chatBody) return () => {};
+
+    const prevScrollHeight = chatBody.scrollHeight;
+    const prevScrollTop = chatBody.scrollTop;
+
+    return () => {
+      const newScrollHeight = chatBody.scrollHeight;
+      if (prevScrollHeight && prevScrollTop && newScrollHeight) {
+        // 상단에 데이터가 추가되므로, 이전 위치를 유지하려면 새 높이 차이를 더함
+        chatBody.scrollTop =
+          prevScrollTop + (newScrollHeight - prevScrollHeight);
+      }
+    };
+  };
+
+  useEffect(
+    () => {
+      if (!scrollToBottomRef.current) return;
+
+      if (isLoadingPastData) {
+        // 과거 데이터 로드 중: 현재 위치 유지
+        const adjustScroll = maintainScrollPosition();
+        requestAnimationFrame(adjustScroll); // DOM 업데이트 후 실행
+      } else {
+        // 새 메시지 추가 시: 하단으로 이동
+        scrollToBottom();
+      }
+    },
+    dependencies ? dependencies : []
+  );
+
+  return { scrollToBottomRef };
+};

--- a/src/components/Chat/hooks.ts
+++ b/src/components/Chat/hooks.ts
@@ -1,6 +1,14 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { ChatCurrentDataType, ChatMessageListType } from './ChatBox/type';
-import { useEffect, useRef } from 'react';
+
+export const scrollToBottom = (
+  scrollToBottomRef: React.RefObject<HTMLDivElement>
+) => {
+  if (scrollToBottomRef.current) {
+    scrollToBottomRef.current.scrollTop =
+      scrollToBottomRef.current.scrollHeight;
+  }
+};
 
 export const useReceivedMessage = () => {
   const queryClient = useQueryClient();
@@ -55,56 +63,52 @@ export const useReceivedMessage = () => {
   return { onMessageReceived };
 };
 
-interface UseScrollToBottomParams {
-  dependencies?: unknown[];
-  isLoadingPastData?: boolean; // 과거 데이터 로드 여부
-}
+// interface UseScrollToBottomParams {
+//   dependencies?: unknown[];
+//   isLoadingPastData?: boolean; // 과거 데이터 로드 여부
+// }
 
-export const useScrollToBottom = ({
-  dependencies,
-  isLoadingPastData = false,
-}: UseScrollToBottomParams) => {
-  const scrollToBottomRef = useRef<HTMLDivElement>(null);
+// export const useScrollToBottom = ({
+//   dependencies,
+//   isLoadingPastData = false,
+// }: UseScrollToBottomParams) => {
+//   const scrollToBottomRef = useRef<HTMLDivElement>(null);
 
-  const scrollToBottom = () => {
-    if (scrollToBottomRef.current) {
-      scrollToBottomRef.current.scrollTop =
-        scrollToBottomRef.current.scrollHeight;
-    }
-  };
+//   const scrollToBottom = () => {
+//     if (scrollToBottomRef.current) {
+//       scrollToBottomRef.current.scrollTop =
+//         scrollToBottomRef.current.scrollHeight;
+//     }
+//   };
 
-  const maintainScrollPosition = () => {
-    const chatBody = scrollToBottomRef.current;
-    if (!chatBody) return () => {};
+//   const maintainScrollPosition = () => {
+//     const chatBody = scrollToBottomRef.current;
+//     if (!chatBody) return;
 
-    const prevScrollHeight = chatBody.scrollHeight;
-    const prevScrollTop = chatBody.scrollTop;
+//     const prevScrollHeight = chatBody.scrollHeight;
+//     const prevScrollTop = chatBody.scrollTop;
 
-    return () => {
-      const newScrollHeight = chatBody.scrollHeight;
-      if (prevScrollHeight && prevScrollTop && newScrollHeight) {
-        // 상단에 데이터가 추가되므로, 이전 위치를 유지하려면 새 높이 차이를 더함
-        chatBody.scrollTop =
-          prevScrollTop + (newScrollHeight - prevScrollHeight);
-      }
-    };
-  };
+//     return () => {
+//       const newScrollHeight = chatBody.scrollHeight;
+//       if (prevScrollHeight && prevScrollTop && newScrollHeight) {
+//         // 상단에 데이터가 추가되므로, 이전 위치를 유지하려면 새 높이 차이를 더함
+//         chatBody.scrollTop =
+//           prevScrollTop + (newScrollHeight - prevScrollHeight);
+//       }
+//     };
+//   };
 
-  useEffect(
-    () => {
-      if (!scrollToBottomRef.current) return;
+//   useEffect(() => {
+//     if (!scrollToBottomRef.current) return;
 
-      if (isLoadingPastData) {
-        // 과거 데이터 로드 중: 현재 위치 유지
-        const adjustScroll = maintainScrollPosition();
-        requestAnimationFrame(adjustScroll); // DOM 업데이트 후 실행
-      } else {
-        // 새 메시지 추가 시: 하단으로 이동
-        scrollToBottom();
-      }
-    },
-    dependencies ? dependencies : []
-  );
+//     if (isLoadingPastData) {
+//       // 과거 데이터 로드 중: 현재 위치 유지
+//       maintainScrollPosition();
+//     } else {
+//       // 새 메시지 추가 시: 하단으로 이동
+//       scrollToBottom();
+//     }
+//   }, dependencies);
 
-  return { scrollToBottomRef };
-};
+//   return { scrollToBottomRef };
+// };

--- a/src/hook/useObserver.ts
+++ b/src/hook/useObserver.ts
@@ -7,12 +7,15 @@ interface InfiniteProps {
 
 export default function useObserver({ threshold = 0.1, event }: InfiniteProps) {
   const obsRef = useRef<HTMLDivElement>(null);
+  const preventRef = useRef(true);
 
   const handleObs: IntersectionObserverCallback = useCallback(
-    entries => {
+    async entries => {
       const target = entries[0];
-      if (target.isIntersecting && event) {
-        event();
+      if (preventRef && target.isIntersecting && event) {
+        preventRef.current = false;
+        await event();
+        preventRef.current = true;
       }
     },
     [event]

--- a/src/hook/useObserver.ts
+++ b/src/hook/useObserver.ts
@@ -7,27 +7,21 @@ interface InfiniteProps {
 
 export default function useObserver({ threshold = 0.1, event }: InfiniteProps) {
   const obsRef = useRef<HTMLDivElement>(null);
-  const preventRef = useRef(true); //옵저버 중복 방지
 
   const handleObs: IntersectionObserverCallback = useCallback(
     entries => {
       const target = entries[0];
       if (target.isIntersecting && event) {
-        //옵저버 중복 실행 방지
-        preventRef.current = false;
         event();
       }
     },
     [event]
   );
 
-  //옵저버 생성
   useEffect(() => {
     const observer = new IntersectionObserver(handleObs, { threshold });
     if (obsRef.current) observer.observe(obsRef.current);
-    return () => {
-      observer.disconnect();
-    };
+    return () => observer.disconnect();
   }, [handleObs, threshold]);
 
   return { obsRef };

--- a/src/hook/useSocket.ts
+++ b/src/hook/useSocket.ts
@@ -16,8 +16,6 @@ export const useSocket = () => {
       extraHeaders: {
         authorization: `Bearer ${token}`,
       },
-      transports: ['polling', 'websocket'],
-      upgrade: false,
     });
     socket.current.connect(); // 수동 연결
 
@@ -38,7 +36,7 @@ export const useSocket = () => {
     return () => {
       socket.current?.disconnect();
     };
-  }, []);
+  }, [socket]);
 
   return socket.current;
 };

--- a/src/hook/useSocket.ts
+++ b/src/hook/useSocket.ts
@@ -24,15 +24,6 @@ export const useSocket = () => {
       toast.error('채팅 서버 연결에 실패했습니다.');
     });
 
-    socket.current.on('reconnect_failed', () => {
-      console.error('재연결 실패');
-      toast.error('서버 연결이 불안정합니다. 페이지를 새로고침해주세요.');
-    });
-
-    socket.current.on('reconnect_attempt', attemptNumber => {
-      console.log(`재연결 시도 ${attemptNumber}`);
-    });
-
     return () => {
       socket.current?.disconnect();
     };

--- a/src/utils/date/formatTime.ts
+++ b/src/utils/date/formatTime.ts
@@ -28,12 +28,14 @@ export default function formatTime({ time, formatType }: formatTimeParams) {
   const minute = date.getMinutes();
   const second = date.getSeconds();
 
+  const formattedHour = hour === 0 || hour === 12 ? 12 : hour % 12;
+
   const timeObj = {
     hms: `${hour}:${minute}:${second}`,
     hm: `${hour}:${minute}`,
     m: `${minute}`,
-    ampm: `${hour > 12 ? 'pm' : 'am'} ${hour % 12}:${minute}`,
-    오전오후: `${hour > 12 ? '오후' : '오전'} ${hour % 12}:${minute}`,
+    ampm: `${hour > 12 ? 'pm' : 'am'} ${formattedHour}:${minute}`,
+    오전오후: `${hour > 12 ? '오후' : '오전'} ${formattedHour}:${minute}`,
   };
 
   return timeObj[formatType || 'hms'];

--- a/vite.config.ts.timestamp-1742909440194-22c8e84efb764.mjs
+++ b/vite.config.ts.timestamp-1742909440194-22c8e84efb764.mjs
@@ -1,0 +1,26 @@
+// vite.config.ts
+import react from "file:///C:/JJ_file/honey-moa-client/honey-moa-dev1/honey-moa-front/node_modules/@vitejs/plugin-react-swc/index.mjs";
+import path from "path";
+var __vite_injected_original_dirname = "C:\\JJ_file\\honey-moa-client\\honey-moa-dev1\\honey-moa-front";
+var vite_config_default = {
+  plugins: [react()],
+  test: {
+    browser: {
+      provider: "webdriverio",
+      enabled: true,
+      name: "chrome",
+      setupFiles: ["./vitest-setup.ts"]
+    }
+  },
+  resolve: {
+    alias: [{ find: "@", replacement: path.resolve(__vite_injected_original_dirname, "src") }]
+  },
+  server: {
+    host: "0.0.0.0",
+    port: 3e3
+  }
+};
+export {
+  vite_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidml0ZS5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9kaXJuYW1lID0gXCJDOlxcXFxKSl9maWxlXFxcXGhvbmV5LW1vYS1jbGllbnRcXFxcaG9uZXktbW9hLWRldjFcXFxcaG9uZXktbW9hLWZyb250XCI7Y29uc3QgX192aXRlX2luamVjdGVkX29yaWdpbmFsX2ZpbGVuYW1lID0gXCJDOlxcXFxKSl9maWxlXFxcXGhvbmV5LW1vYS1jbGllbnRcXFxcaG9uZXktbW9hLWRldjFcXFxcaG9uZXktbW9hLWZyb250XFxcXHZpdGUuY29uZmlnLnRzXCI7Y29uc3QgX192aXRlX2luamVjdGVkX29yaWdpbmFsX2ltcG9ydF9tZXRhX3VybCA9IFwiZmlsZTovLy9DOi9KSl9maWxlL2hvbmV5LW1vYS1jbGllbnQvaG9uZXktbW9hLWRldjEvaG9uZXktbW9hLWZyb250L3ZpdGUuY29uZmlnLnRzXCI7LyogZXNsaW50LWRpc2FibGUgQHR5cGVzY3JpcHQtZXNsaW50L25vLWV4cGxpY2l0LWFueSAqL1xyXG5pbXBvcnQgcmVhY3QgZnJvbSAnQHZpdGVqcy9wbHVnaW4tcmVhY3Qtc3djJztcclxuaW1wb3J0IHBhdGggZnJvbSAncGF0aCc7XHJcblxyXG4vLyBodHRwczovL3ZpdGUuZGV2L2NvbmZpZy9cclxuZXhwb3J0IGRlZmF1bHQge1xyXG4gIHBsdWdpbnM6IFtyZWFjdCgpXSxcclxuICB0ZXN0OiB7XHJcbiAgICBicm93c2VyOiB7XHJcbiAgICAgIHByb3ZpZGVyOiAnd2ViZHJpdmVyaW8nLFxyXG4gICAgICBlbmFibGVkOiB0cnVlLFxyXG4gICAgICBuYW1lOiAnY2hyb21lJyxcclxuICAgICAgc2V0dXBGaWxlczogWycuL3ZpdGVzdC1zZXR1cC50cyddLFxyXG4gICAgfSxcclxuICB9LFxyXG4gIHJlc29sdmU6IHtcclxuICAgIGFsaWFzOiBbeyBmaW5kOiAnQCcsIHJlcGxhY2VtZW50OiBwYXRoLnJlc29sdmUoX19kaXJuYW1lLCAnc3JjJykgfV0sXHJcbiAgfSxcclxuICBzZXJ2ZXI6IHtcclxuICAgIGhvc3Q6ICcwLjAuMC4wJyxcclxuICAgIHBvcnQ6IDMwMDAsXHJcbiAgfSxcclxufTtcclxuIl0sCiAgIm1hcHBpbmdzIjogIjtBQUNBLE9BQU8sV0FBVztBQUNsQixPQUFPLFVBQVU7QUFGakIsSUFBTSxtQ0FBbUM7QUFLekMsSUFBTyxzQkFBUTtBQUFBLEVBQ2IsU0FBUyxDQUFDLE1BQU0sQ0FBQztBQUFBLEVBQ2pCLE1BQU07QUFBQSxJQUNKLFNBQVM7QUFBQSxNQUNQLFVBQVU7QUFBQSxNQUNWLFNBQVM7QUFBQSxNQUNULE1BQU07QUFBQSxNQUNOLFlBQVksQ0FBQyxtQkFBbUI7QUFBQSxJQUNsQztBQUFBLEVBQ0Y7QUFBQSxFQUNBLFNBQVM7QUFBQSxJQUNQLE9BQU8sQ0FBQyxFQUFFLE1BQU0sS0FBSyxhQUFhLEtBQUssUUFBUSxrQ0FBVyxLQUFLLEVBQUUsQ0FBQztBQUFBLEVBQ3BFO0FBQUEsRUFDQSxRQUFRO0FBQUEsSUFDTixNQUFNO0FBQUEsSUFDTixNQUFNO0FBQUEsRUFDUjtBQUNGOyIsCiAgIm5hbWVzIjogW10KfQo=


### PR DESCRIPTION
## #️⃣연관된 이슈

> #122 

## 📝작업 내용

> 소켓 채팅 연결

> 수정이 필요한 부분

- [x] 페이지 네이션시 `obsRef`에 따라서 값을 불러올 수 있도록 추가 (현재 추가는 되어있지만 제대로 동작하지 않음)
- [x] 타입 에러 해결 => 현재, queryClinet를 통해서 oldData를 받아서 낙관적 업데이트를 시키고 있는데, oldData를 사용하기 위해서 타입 정의가 필요합니다. 
- 모듈화
   - [x] queryClient를 통해서 `received_message`부분과, `send_message`에서 모두 사용하고 있는데, 이걸 하나로 만들어서 효율적으로 관리할 수 있도록 변경 필요
- [x] 현재 채팅 모달이 닫힌 상태면, `received_message`를 판단하지 못함 (컴포넌트 내부에 존재하기 때문) => 이걸 상위 컴포넌트로 끌어 올려야 함
- [ ] 현재 chat이 최 상위에 위치하는데, 적절한 위치를 생각해볼 필요가 있음

> 추가가 필요하 기능 

- 채팅 이미지 추가(백엔드에서 api만들어줘야 함)
- 채팅 수정(api 만들어줘야 함)
- 채팅 삭제 (api 만들어줘야 함)
- 상대방 채팅이 왔을 시, 알람이 울릴 수 있도록 만들기 => `toast` 사용해서 띄우기?
### 스크린샷 (선택)

https://github.com/user-attachments/assets/bea25fa4-3a23-49aa-a7a3-e4a467e817a0


## 💬리뷰 요구사항(선택)

> 리팩터링

- 현재 하나의 컴포넌트에서 기능만 추가해본 상태 입니다. 그래서 많은 기능이 하나의 컴포넌트에서 동작하고 그에 따라 컴포넌트 복잡도가 많이 높아졌습니다. 
- **컴포넌트 분리 관점에서 어떤 부분에 대해 분리하면 좋을지 중심으로 리뷰해주시면 감사하겠습니다**.
