### PR TITLE
비로그인 사용자로 액세스 버그 수정

### DIFF
--- a/src/apis/attachment/error.ts
+++ b/src/apis/attachment/error.ts
@@ -4,7 +4,6 @@ import { ErrorResponse } from '../type';
 export function createAttachmentErrorHandler(error: AxiosError) {
   const responseData = error.response?.data as ErrorResponse;
   const code = responseData?.code;
-  console.log(responseData);
   if (
     responseData.errors[0].reason ===
     'File must be of one of the types image/png, image/jpeg, video/mp4, video/quicktime'

--- a/src/apis/auth/queries.ts
+++ b/src/apis/auth/queries.ts
@@ -15,9 +15,7 @@ export const LoginQuery = () => {
       queryClient.invalidateQueries({
         queryKey: ['auth-sign-in'],
       });
-      queryClient.invalidateQueries({
-        queryKey: ['chat-rooms', 'me'],
-      });
+      queryClient.clear();
       setToken(data.accessToken);
       setRefreshToken(data.refreshToken);
       toast.success('로그인 성공');

--- a/src/apis/blog/endpoint.ts
+++ b/src/apis/blog/endpoint.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios';
 import { instanceToken } from '../axiosInstance';
 import {
   BlogHoneyType,
@@ -26,9 +27,16 @@ export async function postCreateBlog(
 //블로그 단일 조회
 export async function getSingleBlog({
   id,
-}: BlogSingleParamsType): Promise<BlogSingleInfoReturn> {
-  const response = await instanceToken.get(`/users/${id}/blog`);
-  return response.data;
+}: BlogSingleParamsType): Promise<BlogSingleInfoReturn | null> {
+  try {
+    const response = await instanceToken.get(`/users/${id}/blog`);
+    return response.data;
+  } catch (error) {
+    if (error instanceof Error && (error as AxiosError).status === 404) {
+      return null;
+    }
+  }
+  return null;
 }
 
 //블로그 커플 정보 수정

--- a/src/apis/blog/queries.ts
+++ b/src/apis/blog/queries.ts
@@ -12,7 +12,6 @@ import {
   deleteBlogPostErrorHandler,
   editBlogProfileErrorHandler,
   getBlogHoneyErrorHandler,
-  getSingleBlogErrorHandler,
   PaginationErrorHandler,
   updateBlogPostErrorHandler,
 } from './error';
@@ -43,16 +42,12 @@ export const CreateBlogMutate = () => {
 
 //블로그 단일 조회 query
 export const GetSingleBlogQuery = (id?: string) => {
-  const { data, isError, error } = useSuspenseQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ['single-blog', id],
     queryFn: () => BlogEndpoint.getSingleBlog({ id }),
     retry: false,
     refetchOnWindowFocus: false,
   });
-  if (isError) {
-    toast.error(getSingleBlogErrorHandler(error as AxiosError));
-    return null;
-  }
   return data;
 };
 

--- a/src/components/Blog/Post/Comments/BlogComments.tsx
+++ b/src/components/Blog/Post/Comments/BlogComments.tsx
@@ -24,7 +24,6 @@ export default function BlogComments() {
   const commentTextRef = useRef<HTMLTextAreaElement>(null);
 
   const myInfo = UserQueries.GetMyInfoQuery();
-
   const commentList = BlogCommentsQueries.useBlogPostCommentsPaginationQuery({
     id: honeyData?.id,
   });

--- a/src/components/Error/ErrorBoundary.tsx
+++ b/src/components/Error/ErrorBoundary.tsx
@@ -43,6 +43,7 @@
 
 import { useQueryErrorResetBoundary } from '@tanstack/react-query'; // (*)
 import { ErrorBoundary } from 'react-error-boundary'; // (*)
+import Fallback from './Fallback';
 
 interface Props {
   children: React.ReactNode;
@@ -55,11 +56,7 @@ const QueryErrorBoundary = ({ children }: Props) => {
     <ErrorBoundary
       onReset={reset}
       fallbackRender={({ resetErrorBoundary }) => (
-        <div>
-          <p>페이지를 불러오는데 실패했습니다.</p>
-          <p>재시도 해주세요.</p>
-          <button onClick={() => resetErrorBoundary()}>재시도</button>
-        </div>
+        <Fallback resetErrorBoundary={resetErrorBoundary} />
       )}
     >
       {children}

--- a/src/components/Layouts/Header/BlogHeader.tsx
+++ b/src/components/Layouts/Header/BlogHeader.tsx
@@ -4,11 +4,10 @@ import * as S from './style';
 import { BlogHeaderProps } from './type';
 import Image from '@/components/Image';
 import CustomLink from '@/components/common/CustomLink';
-import { Loading } from '@/components';
 import { BlogQueries } from '@/apis/blog';
 import { UserQueries } from '@/apis/user';
 
-export default function Blog({ visible }: BlogHeaderProps) {
+export default function Blog({ visible = true }: BlogHeaderProps) {
   const myInfo = UserQueries.GetMyInfoQuery();
   const getBlogInfo = BlogQueries.GetSingleBlogQuery(myInfo?.id);
   const theme = useTheme();
@@ -17,7 +16,7 @@ export default function Blog({ visible }: BlogHeaderProps) {
     <S.BlogHeaderWrapper $visible={visible}>
       <S.TitleContainer>
         <CustomLink
-          to={getBlogInfo ? `/blog/${getBlogInfo.id}` : '#'}
+          to={getBlogInfo ? `/blog/${getBlogInfo.id}` : '/blog'}
           scrollTop={true}
         >
           <Image
@@ -28,7 +27,10 @@ export default function Blog({ visible }: BlogHeaderProps) {
           />
         </CustomLink>
         {!getBlogInfo ? (
-          <Loading.SkeletonUI width="150px" height="24px" />
+          <>
+            <Svg.UnConnectedIcon size={24} />
+            <h1>커플 연결이 필요합니다</h1>
+          </>
         ) : (
           <h1>{getBlogInfo.name}</h1>
         )}

--- a/src/components/Layouts/SideNavigate/AbleBlogSide.tsx
+++ b/src/components/Layouts/SideNavigate/AbleBlogSide.tsx
@@ -22,7 +22,7 @@ export default function AbleBlogSideNav() {
         <li>
           <PopUp.Tooltip message="포스트 작성" direction="right">
             <CustomLink
-              to={getBlogInfo ? `/blog/${getBlogInfo.id}/post/create` : '#'}
+              to={getBlogInfo ? `/blog/${getBlogInfo.id}/post/create` : '#`'}
             >
               <S.ItemButton disabled={!getBlogInfo}>
                 <Svg.WriteIcon size={36} color={theme.text.primary} />

--- a/src/components/Layouts/SideNavigate/AbleBlogSide.tsx
+++ b/src/components/Layouts/SideNavigate/AbleBlogSide.tsx
@@ -24,7 +24,7 @@ export default function AbleBlogSideNav() {
             <CustomLink
               to={getBlogInfo ? `/blog/${getBlogInfo.id}/post/create` : '#'}
             >
-              <S.ItemButton>
+              <S.ItemButton disabled={!getBlogInfo}>
                 <Svg.WriteIcon size={36} color={theme.text.primary} />
               </S.ItemButton>
             </CustomLink>

--- a/src/components/Layouts/SideNavigate/UnConnectedSide.tsx
+++ b/src/components/Layouts/SideNavigate/UnConnectedSide.tsx
@@ -6,11 +6,11 @@ export default function UnConnectedSideNav() {
   return (
     <S.NavWrapper>
       <S.NavItemListContainer>
-        <li>
+        {/* <li>
           <S.ItemButtonDisabled disabled>
             <Svg.LikeIcon size={36} color="" />
           </S.ItemButtonDisabled>
-        </li>
+        </li> */}
         <li>
           <Link to="/post">
             <S.ItemButtonDisabled disabled>

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -44,7 +44,6 @@ export default function Main() {
             <CreateBlogModal />
           </Modal>
         )}
-
         <div>
           <UnConnectedProfile />
           <Contents.UnConnectedList />

--- a/src/components/common/CustomLink.tsx
+++ b/src/components/common/CustomLink.tsx
@@ -1,6 +1,6 @@
 import useSessionStorage from '@/hook/useSessionStorage';
 import React, { AnchorHTMLAttributes, ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 interface CustomLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string;
@@ -24,9 +24,9 @@ const CustomLink = ({ to, children, scrollTop, ...props }: CustomLinkProps) => {
   };
 
   return (
-    <a href={to} onClick={handleClick} {...props}>
+    <Link to={to} onClick={handleClick} {...props}>
       {children}
-    </a>
+    </Link>
   );
 };
 

--- a/src/routes/AccessAuth.tsx
+++ b/src/routes/AccessAuth.tsx
@@ -9,17 +9,16 @@ export default function AccessAuth({ isPrivate }: AccessAuthProps) {
   const { Funnel, setStep } = useFunnel<AuthFunnelStep>('로그인');
   const { value: token } = useLocalStorage('accessToken');
 
-  return (
-    <>
-      {isPrivate && !token && (
-        <AuthFunnelModal
-          Funnel={Funnel}
-          setStep={setStep}
-          isShow={true}
-          outSideClick={false}
-        />
-      )}
-      <Outlet />
-    </>
-  );
+  if (isPrivate && !token) {
+    return (
+      <AuthFunnelModal
+        Funnel={Funnel}
+        setStep={setStep}
+        isShow={true}
+        outSideClick={false}
+      />
+    );
+  }
+
+  return <Outlet />;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #127 

## 📝작업 내용

> 버그수정

- 비로그인 사용자가, 액세스 하면, ErrorBoundary를 통해서 500 페이지를 띄워주는 버그를 해결했습니다.
- 백엔드에서 404 던져주는 걸로, 블로그가 있는지 없는지를 판단했는데, 단순히 try-catch 걸어서 null 값만 전달해 주면 되는 문제였습니다.
- 시간만 축내고, query쪽만 주구 장창 수정하다가, endpoint쪽을 한 번 건드니깐 해결됐네요...

> 추가 수정

- 버그 수정하면서, 새롭게 로그인 시, 새로운 데이터를 받아올 수 있도록 `queryClient.clear()`를 주었습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 작업하며 느낀점

- 이번 작업을 진행하면서 느낀게, blog 과 blog/:id 를 나눠놓을 필요가 있을까 였습니다.
- 현재는 blog가 없는 사용자이면서, connection이 진행되지 않은 사용하는 blog로
- connnection이 있고, 블로그가 존재한다면, blog/:id 로 보냅니다.
-  거의 동일한 화면을 보여주는 component지만 서로 다른 Main과 Blog라는 컴포넌트를 사용합니다. 이걸 하나로 합치는게 좋을지, 그냥 지금처럼 두 개로 나눠놓는게 좋을 지 잘 모르겠습니다.
