### PR TITLE
auth 관련 수정

### DIFF
--- a/src/apis/auth/endpoint.ts
+++ b/src/apis/auth/endpoint.ts
@@ -75,8 +75,9 @@ export async function putChangePassword({
   return response.data;
 }
 
-export async function reissueAccessToken(): Promise<ReissueAccessTokenReturn> {
-  const refreshToken = window.localStorage.getItem('refreshToken');
+export async function reissueAccessToken(
+  token: string | null
+): Promise<ReissueAccessTokenReturn> {
   const response = await axios.post(
     `${import.meta.env.BASE_URL}/api/v1/auth/reissue/access-token`,
     {},
@@ -84,7 +85,7 @@ export async function reissueAccessToken(): Promise<ReissueAccessTokenReturn> {
       headers: {
         'X-Api-Key': import.meta.env.VITE_API_KEY,
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${refreshToken}`,
+        Authorization: `Bearer ${token}`,
       },
     }
   );

--- a/src/apis/auth/endpoint.ts
+++ b/src/apis/auth/endpoint.ts
@@ -8,6 +8,7 @@ import {
   RegisterReturn,
   ReissueAccessTokenReturn,
 } from './type';
+import axios from 'axios';
 
 //로그인 api
 export async function postToken(loginInfo: LoginRequest): Promise<LoginReturn> {
@@ -76,11 +77,13 @@ export async function putChangePassword({
 
 export async function reissueAccessToken(): Promise<ReissueAccessTokenReturn> {
   const refreshToken = window.localStorage.getItem('refreshToken');
-  const response = await commonInstance.post(
-    '/auth/reissue/access-token',
+  const response = await axios.post(
+    `${import.meta.env.BASE_URL}/api/v1/auth/reissue/access-token`,
     {},
     {
       headers: {
+        'X-Api-Key': import.meta.env.VITE_API_KEY,
+        'Content-Type': 'application/json',
         Authorization: `Bearer ${refreshToken}`,
       },
     }

--- a/src/apis/auth/queries.ts
+++ b/src/apis/auth/queries.ts
@@ -1,31 +1,24 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AuthEndPoint } from '.';
 import { AxiosError } from 'axios';
-import useLocalStorage from '@/hook/useLocalStorage';
-import { toast } from 'react-toastify';
 
 /** 로그인 쿼리 */
 export const useLoginQuery = () => {
-  const { set: setToken } = useLocalStorage('accessToken');
-  const { set: setRefreshToken } = useLocalStorage('refreshToken');
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: AuthEndPoint.postToken,
-    onSuccess: data => {
+    onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['auth-sign-in'],
       });
       queryClient.clear();
-      setToken(data.accessToken);
-      setRefreshToken(data.refreshToken);
-      toast.success('로그인 성공');
     },
     onError: (error: AxiosError) => error,
   });
 };
 
 /** 회원가입 쿼리 */
-export const RegisterQuery = () => {
+export const useRegisterQuery = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: AuthEndPoint.postUserRegister,
@@ -39,7 +32,7 @@ export const RegisterQuery = () => {
 };
 
 /**비밀번호 변경을 위한 이메일 인증 쿼리 */
-export const SendEmailForChangePwQuery = () => {
+export const useSendEmailForChangePwQuery = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: AuthEndPoint.postEmailForChangePw,
@@ -53,27 +46,13 @@ export const SendEmailForChangePwQuery = () => {
 };
 
 /**비밀번호 변경을 위한 쿼리 */
-export const ChangePasswordQuery = () => {
+export const useChangePasswordQuery = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: AuthEndPoint.putChangePassword,
     onSuccess: () => {
       return queryClient.invalidateQueries({
         queryKey: ['password-change'],
-      });
-    },
-    onError: (error: AxiosError) => error,
-  });
-};
-
-/**토큰 재발급 */
-export const ReissueAccessTokenMutate = () => {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: AuthEndPoint.reissueAccessToken,
-    onSuccess: () => {
-      return queryClient.invalidateQueries({
-        queryKey: ['reissue-access-token'],
       });
     },
     onError: (error: AxiosError) => error,

--- a/src/apis/auth/queries.ts
+++ b/src/apis/auth/queries.ts
@@ -5,7 +5,7 @@ import useLocalStorage from '@/hook/useLocalStorage';
 import { toast } from 'react-toastify';
 
 /** 로그인 쿼리 */
-export const LoginQuery = () => {
+export const useLoginQuery = () => {
   const { set: setToken } = useLocalStorage('accessToken');
   const { set: setRefreshToken } = useLocalStorage('refreshToken');
   const queryClient = useQueryClient();

--- a/src/apis/auth/type.d.ts
+++ b/src/apis/auth/type.d.ts
@@ -12,6 +12,7 @@ export interface RegisterReturn {
 export interface LoginRequest {
   email: string;
   password: string;
+  isAutoLogin?: boolean;
 }
 
 export interface LoginReturn {

--- a/src/apis/interceptors.ts
+++ b/src/apis/interceptors.ts
@@ -8,6 +8,7 @@ import {
 import { AuthEndPoint } from './auth';
 import { instanceToken } from './axiosInstance';
 import { toast } from 'react-toastify';
+import { isStorageWithKey } from '@/utils/storage/isStorageWithKey';
 
 //요청 인터셉터
 export function CommonRequestInterceptor(
@@ -30,9 +31,11 @@ export function TokenRequestInterceptor(
   config: InternalAxiosRequestConfig
 ): InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig> {
   config.headers['X-Api-Key'] = import.meta.env.VITE_API_KEY;
-  const accessToken = window.localStorage.getItem('accessToken');
+  const accessToken = isStorageWithKey('accessToken')
+    ? window.localStorage.getItem('accessToken')
+    : window.sessionStorage.getItem('accessToken');
   if (accessToken) {
-    config.headers['Authorization'] = `Bearer ${accessToken}`;
+    config.headers['Authorization'] = `Bearer ${JSON.parse(accessToken)}`;
   } else {
     throw new Error('로그인한 사용자가 아닙니다.');
   }
@@ -46,8 +49,11 @@ export async function ErrorInterceptor(error: AxiosError) {
 
   if (error.response?.status === 401 && !originalRequest._retry) {
     originalRequest._retry = true;
+    const refreshToken = isStorageWithKey('refreshToken')
+      ? window.localStorage.getItem('refreshToken')
+      : window.sessionStorage.getItem('refreshToken');
     try {
-      const newToken = await AuthEndPoint.reissueAccessToken();
+      const newToken = await AuthEndPoint.reissueAccessToken(refreshToken);
       originalRequest.headers = {
         ...originalRequest.headers,
         Authorization: `Bearer ${newToken.accessToken}`,
@@ -57,8 +63,13 @@ export async function ErrorInterceptor(error: AxiosError) {
     } catch (error) {
       // refreshToken 만료시 로그아웃 처리
       toast.error('회원 인증이 만료되었습니다. 다시 로그인 해주세요.');
-      window.localStorage.removeItem('accessToken');
-      window.localStorage.removeItem('refreshToken');
+      if (isStorageWithKey('accessToken')) {
+        window.localStorage.removeItem('accessToken');
+        window.localStorage.removeItem('refreshToken');
+      } else {
+        window.sessionStorage.removeItem('accessToken');
+        window.sessionStorage.removeItem('refreshToken');
+      }
       return Promise.reject(error);
     }
   }

--- a/src/apis/interceptors.ts
+++ b/src/apis/interceptors.ts
@@ -1,8 +1,13 @@
 //요청 인터셉터
-import { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
-import { toast } from 'react-toastify';
+import {
+  AxiosError,
+  AxiosRequestConfig,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from 'axios';
 import { AuthEndPoint } from './auth';
 import { instanceToken } from './axiosInstance';
+import { toast } from 'react-toastify';
 
 //요청 인터셉터
 export function CommonRequestInterceptor(
@@ -10,6 +15,14 @@ export function CommonRequestInterceptor(
 ): InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig> {
   config.headers['X-Api-Key'] = import.meta.env.VITE_API_KEY;
   return config;
+}
+
+//응답 인터셉터
+export function CommonResponseInterceptor(
+  response: AxiosResponse
+): AxiosResponse {
+  // Do something with response data
+  return response;
 }
 
 //토큰 있는 요청 인터셉터
@@ -26,45 +39,28 @@ export function TokenRequestInterceptor(
   return config;
 }
 
-//응답 인터셉터
-export function CommonResponseInterceptor(
-  response: AxiosResponse
-): AxiosResponse {
-  // Do something with response data
-  return response;
-}
-
 //에러 인터셉터
 export async function ErrorInterceptor(error: AxiosError) {
-  const { code } = error.response?.data as { code: string };
-  if (code === 'INVALID_TOKEN') {
-    try {
-      const response = await AuthEndPoint.reissueAccessToken();
-      window.localStorage.setItem('accessToken', response.accessToken);
+  const { config } = error;
+  const originalRequest = config as AxiosRequestConfig & { _retry?: boolean };
 
-      if (error.config) {
-        error.config.headers[
-          'Authorization'
-        ] = `Bearer ${response.accessToken}`;
-        const result = await instanceToken(error.config);
-        return result;
-      }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      const { code } = error.response?.data as { code: string };
-      if (code === 'INVALID_TOKEN') {
-        toast.error('토근 재발급에 실패했습니다. 다시 로그인 해 주세요');
-        window.location.href = '/root';
-        window.localStorage.clear();
-        return;
-      } else {
-        toast.error('서버 오류 입니다. 잠시 후 다시 시도해주세요.');
-        return;
-      }
+  if (error.response?.status === 401 && !originalRequest._retry) {
+    originalRequest._retry = true;
+    try {
+      const newToken = await AuthEndPoint.reissueAccessToken();
+      originalRequest.headers = {
+        ...originalRequest.headers,
+        Authorization: `Bearer ${newToken.accessToken}`,
+      };
+      // 재요청
+      return instanceToken(originalRequest);
+    } catch (error) {
+      // refreshToken 만료시 로그아웃 처리
+      toast.error('회원 인증이 만료되었습니다. 다시 로그인 해주세요.');
+      window.localStorage.removeItem('accessToken');
+      window.localStorage.removeItem('refreshToken');
+      return Promise.reject(error);
     }
-  }
-  if (code === 'SERVER_ERROR') {
-    return toast.error('서버 오류 입니다. 잠시 후 다시 시도해주세요.');
   }
   return Promise.reject(error);
 }

--- a/src/components/Auth/ChangePassword.tsx
+++ b/src/components/Auth/ChangePassword.tsx
@@ -26,7 +26,7 @@ export default function ChangePassword() {
   const onChangeNewPasswordInfo = passwordChange.text({
     setState: setChangeInfo,
   });
-  const mutationChangePassword = AuthQueries.ChangePasswordQuery();
+  const mutationChangePassword = AuthQueries.useChangePasswordQuery();
 
   const onSubmitChangePassword: React.FormEventHandler<HTMLFormElement> = e => {
     e.preventDefault();

--- a/src/components/Auth/LoginModal.tsx
+++ b/src/components/Auth/LoginModal.tsx
@@ -30,7 +30,7 @@ export default function LoginModal({ setStep }: ModalProps<AuthFunnelStep>) {
     key: 'isAutoLogin',
   });
 
-  const mutation = AuthQueries.LoginQuery();
+  const mutation = AuthQueries.useLoginQuery();
 
   const onSubmit: React.FormEventHandler<HTMLFormElement> = e => {
     e.preventDefault();

--- a/src/components/Auth/LoginModal.tsx
+++ b/src/components/Auth/LoginModal.tsx
@@ -9,8 +9,18 @@ import { Loading } from '..';
 import { LoginErrorHandler } from '@/apis/auth/error';
 import { changeInfo } from '@/utils';
 import { toast } from 'react-toastify';
+import useLocalStorage from '@/hook/useLocalStorage';
+import useSessionStorage from '@/hook/useSessionStorage';
 
 export default function LoginModal({ setStep }: ModalProps<AuthFunnelStep>) {
+  const { set: setAccessTokenToLocalStorage } = useLocalStorage('accessToken');
+  const { set: setRefreshTokenToLocalStorage } =
+    useLocalStorage('refreshToken');
+  const { set: setAccessTokenToSessionStorage } =
+    useSessionStorage('accessToken');
+  const { set: setRefreshTokenToSessionStorage } =
+    useSessionStorage('refreshToken');
+
   const [loginInfo, setLoginInfo] = useState<LoginInfo>({
     email: '',
     password: '',
@@ -34,13 +44,23 @@ export default function LoginModal({ setStep }: ModalProps<AuthFunnelStep>) {
 
   const onSubmit: React.FormEventHandler<HTMLFormElement> = e => {
     e.preventDefault();
-    const { email, password } = loginInfo;
+    const { email, password, isAutoLogin } = loginInfo;
     const isValid = validationLoginInfo(loginInfo);
     if (isValid.result) {
       mutation.mutate(
-        { email, password },
+        { email, password, isAutoLogin },
         {
-          onSuccess: () => navigate('/blog'),
+          onSuccess: data => {
+            navigate('/blog');
+            if (isAutoLogin) {
+              setAccessTokenToLocalStorage(data.accessToken);
+              setRefreshTokenToLocalStorage(data.refreshToken);
+            } else {
+              setAccessTokenToSessionStorage(data.accessToken);
+              setRefreshTokenToSessionStorage(data.refreshToken);
+            }
+            toast.success('로그인 성공');
+          },
           onError: error => {
             toast.error(LoginErrorHandler(error));
           },
@@ -55,7 +75,7 @@ export default function LoginModal({ setStep }: ModalProps<AuthFunnelStep>) {
     <S.ModalWrapper>
       <S.ModalHeader>
         <Image
-          src="siteLogo.jpg"
+          src="/images/siteLogo.jpg"
           alt="intro"
           width="36px"
           height="36px"

--- a/src/components/Auth/RegisterModal.tsx
+++ b/src/components/Auth/RegisterModal.tsx
@@ -32,8 +32,8 @@ export default function RegisterModal({ setStep }: ModalProps<AuthFunnelStep>) {
     key: 'conditions',
   });
 
-  const mutationRegister = AuthQueries.RegisterQuery();
-  const mutationLogin = AuthQueries.LoginQuery();
+  const mutationRegister = AuthQueries.useRegisterQuery();
+  const mutationLogin = AuthQueries.useLoginQuery();
 
   const onSubmitRegister: React.FormEventHandler<HTMLFormElement> = e => {
     e.preventDefault();
@@ -67,7 +67,7 @@ export default function RegisterModal({ setStep }: ModalProps<AuthFunnelStep>) {
       <S.ModalWrapper>
         <S.ModalHeader>
           <Image
-            src="siteLogo.jpg"
+            src="images/siteLogo.jpg"
             alt="intro"
             width="36px"
             height="36px"

--- a/src/components/Auth/SendEmailForChangePasswordModal.tsx
+++ b/src/components/Auth/SendEmailForChangePasswordModal.tsx
@@ -17,7 +17,7 @@ export default function SendEmailForChangePasswordModal<T>({
     email: '',
   });
 
-  const mutationSendEmail = AuthQueries.SendEmailForChangePwQuery();
+  const mutationSendEmail = AuthQueries.useSendEmailForChangePwQuery();
 
   const onChangeEmailForChangePw = changeInfo.text<EmailForChangePwType>({
     setState: setForChangePw,

--- a/src/components/Blog/UnConnectBlog/CreateBlogModal/index.tsx
+++ b/src/components/Blog/UnConnectBlog/CreateBlogModal/index.tsx
@@ -26,15 +26,21 @@ export default function CreateBlogModal() {
   });
 
   const createBlogMutate = BlogQueries.CreateBlogMutate();
-  const { remove: removeLocalStorage } = useLocalStorage('accessToken');
-  const { remove: removeSessionStorage } = useSessionStorage('refreshToken');
+  const { remove: removeAccessTokenInLocalStorage } =
+    useLocalStorage('accessToken');
+  const { remove: removeRefreshTokenInLocalStorage } =
+    useLocalStorage('refreshToken');
+  const { remove: removeAccessTokenInSessionStorage } =
+    useSessionStorage('accessToken');
+  const { remove: removeRefreshTokenInSessionStorage } =
+    useSessionStorage('refreshToken');
 
   const logoutHandler = () => {
-    removeLocalStorage('accessToken');
-    removeLocalStorage('refreshToken');
+    removeAccessTokenInLocalStorage();
+    removeRefreshTokenInLocalStorage();
 
-    removeSessionStorage('accessToken');
-    removeSessionStorage('refreshToken');
+    removeAccessTokenInSessionStorage();
+    removeRefreshTokenInSessionStorage();
     navigate('/root');
   };
 

--- a/src/components/Chat/ChatBox.tsx
+++ b/src/components/Chat/ChatBox.tsx
@@ -8,11 +8,19 @@ import { changeInfo } from '@/utils';
 import { scrollToBottom } from './utils';
 import { useMessageListener } from './hooks';
 import { useSocket } from '@/hook/useSocket';
+import useSessionStorage from '@/hook/useSessionStorage';
+import { isStorageWithKey } from '@/utils/storage/isStorageWithKey';
 
 export default function ChatBox() {
   const [isOpenChatModal, setIsOpenChatModal] = useState(false);
-  const { value: token } = useLocalStorage('accessToken');
+  const { value: accessTokenInLocalStorage } = useLocalStorage('accessToken');
+  const { value: accessTokenInSessionStorage } =
+    useSessionStorage('accessToken');
   const belongToChatRoom = ChatQueries.useGetBelongToChatRoom();
+
+  const token = isStorageWithKey('accessToken')
+    ? accessTokenInLocalStorage
+    : accessTokenInSessionStorage;
 
   const scrollToBottomRef = useRef<HTMLDivElement>(null);
   const socket = useSocket();

--- a/src/hook/useLocalStorage.ts
+++ b/src/hook/useLocalStorage.ts
@@ -1,6 +1,8 @@
 import { useCallback, useMemo, useSyncExternalStore } from 'react';
 import { toast } from 'react-toastify';
 
+const STORAGE_EVENT_NAME = 'local-storage-event';
+
 /**
  *
  * @param key 스토리지에 저장될 키 값
@@ -25,15 +27,15 @@ import { toast } from 'react-toastify';
  * </>
  * )
  */
-export default function useLocalStorage(
+export default function useLocalStorage<T = string>(
   key: string,
-  initialValue?: string | null
+  initialValue?: T
 ) {
   const getSnapshot = () => localStorage.getItem(key);
 
   const subscribe = (listener: () => void) => {
-    window.addEventListener('storage', listener);
-    return () => window.removeEventListener('storage', listener);
+    window.addEventListener(STORAGE_EVENT_NAME, listener);
+    return () => window.removeEventListener(STORAGE_EVENT_NAME, listener);
   };
 
   const externalStoreState = useSyncExternalStore(subscribe, getSnapshot);
@@ -43,10 +45,13 @@ export default function useLocalStorage(
   }, [externalStoreState, initialValue]);
 
   const setStorage = useCallback(
-    (newValue: string) => {
+    (newValue: unknown) => {
       try {
-        localStorage.setItem(key, newValue);
-        dispatchEvent(new StorageEvent('storage', { key: key, newValue }));
+        const valueToStore = JSON.stringify(newValue);
+        localStorage.setItem(key, valueToStore);
+        dispatchEvent(
+          new StorageEvent(STORAGE_EVENT_NAME, { key, newValue: valueToStore })
+        );
       } catch (error) {
         toast.error(`스토리지에 저장하는데 문제가 발생했습니다: ${error}`);
       }
@@ -54,23 +59,14 @@ export default function useLocalStorage(
     [key]
   );
 
-  const removeStorage = useCallback(
-    (removeValue: string) => {
-      localStorage.removeItem(removeValue);
-      dispatchEvent(new StorageEvent('storage', { key: removeValue }));
-    },
-    [key]
-  );
-
-  const clearStorage = useCallback(() => {
-    localStorage.clear();
-    dispatchEvent(new StorageEvent('storage', { key: key }));
+  const removeStorage = useCallback(() => {
+    localStorage.removeItem(key);
+    dispatchEvent(new StorageEvent(STORAGE_EVENT_NAME, { key }));
   }, [key]);
 
   return {
     value: store,
     set: setStorage,
     remove: removeStorage,
-    clear: clearStorage,
   };
 }

--- a/src/hook/useSessionStorage.ts
+++ b/src/hook/useSessionStorage.ts
@@ -1,15 +1,17 @@
 import { useCallback, useMemo, useSyncExternalStore } from 'react';
 import { toast } from 'react-toastify';
 
-export default function useSessionStorage(
+const STORAGE_EVENT_NAME = 'local-storage-event';
+
+export default function useSessionStorage<T = string>(
   key: string,
-  initialValue?: string | null
+  initialValue?: T
 ) {
   const getSnapshot = () => sessionStorage.getItem(key);
 
   const subscribe = (listener: () => void) => {
-    window.addEventListener('storage', listener);
-    return () => window.removeEventListener('storage', listener);
+    window.addEventListener(STORAGE_EVENT_NAME, listener);
+    return () => window.removeEventListener(STORAGE_EVENT_NAME, listener);
   };
 
   const externalStoreState = useSyncExternalStore(subscribe, getSnapshot);
@@ -20,11 +22,11 @@ export default function useSessionStorage(
 
   const setStorage = useCallback(
     (newValue: unknown) => {
-      const parsedValue = JSON.stringify(newValue);
       try {
+        const parsedValue = JSON.stringify(newValue);
         sessionStorage.setItem(key, parsedValue);
         dispatchEvent(
-          new StorageEvent('storage', { key: key, newValue: parsedValue })
+          new StorageEvent(STORAGE_EVENT_NAME, { key, newValue: parsedValue })
         );
       } catch (error) {
         toast.error(`스토리지에 저장하는데 문제가 발생했습니다: ${error}`);
@@ -33,23 +35,14 @@ export default function useSessionStorage(
     [key]
   );
 
-  const removeStorage = useCallback(
-    (removeValue: string) => {
-      sessionStorage.removeItem(removeValue);
-      dispatchEvent(new StorageEvent('storage', { key: removeValue }));
-    },
-    [key]
-  );
-
-  const clearStorage = useCallback(() => {
-    sessionStorage.clear();
-    dispatchEvent(new StorageEvent('storage', { key: key }));
+  const removeStorage = useCallback(() => {
+    sessionStorage.removeItem(key);
+    dispatchEvent(new StorageEvent(STORAGE_EVENT_NAME, { key }));
   }, [key]);
 
   return {
     value: store,
     set: setStorage,
     remove: removeStorage,
-    clear: clearStorage,
   };
 }

--- a/src/routes/AccessAuth.tsx
+++ b/src/routes/AccessAuth.tsx
@@ -4,10 +4,18 @@ import useFunnel from '@/hook/useFunnel';
 import { AccessAuthProps } from './type';
 import useLocalStorage from '@/hook/useLocalStorage';
 import { Outlet } from 'react-router-dom';
+import useSessionStorage from '@/hook/useSessionStorage';
+import { isStorageWithKey } from '@/utils/storage/isStorageWithKey';
 
 export default function AccessAuth({ isPrivate }: AccessAuthProps) {
   const { Funnel, setStep } = useFunnel<AuthFunnelStep>('로그인');
-  const { value: token } = useLocalStorage('accessToken');
+  const { value: accessTokenInLocalStorage } = useLocalStorage('accessToken');
+  const { value: accessTokenInSessionStorage } =
+    useSessionStorage('accessToken');
+
+  const token = isStorageWithKey('accessToken')
+    ? accessTokenInLocalStorage
+    : accessTokenInSessionStorage;
 
   if (isPrivate && !token) {
     return (

--- a/src/utils/storage/isStorageWithKey.ts
+++ b/src/utils/storage/isStorageWithKey.ts
@@ -1,0 +1,3 @@
+export function isStorageWithKey(key: string) {
+  return window.localStorage.getItem(key) !== null;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #136 

## 📝작업 내용

> auth 토큰 재발급시 무한호출 되던 오류해결

> auth localStorage와 sessionStorage로 저장할 수 있도록 분리

- 이 부분은 백엔드와 이야기해본 결론으로 accessToken은 loacl혹은 session에 저장하고, refresh토큰은 cookie에 저장하기로 했습니다. 아직 백엔드에 cookie저장로직이 없어서 이렇게 구현하고 머지하겠습니다.

> useLocalStorage와 useSessionStorage 수정

- delete함수는 key값을 제외한 다른 값을 제거하는게, 관심사 분리가 안된다는 느낌이라 삭제했습니다
- clear 함수가 hook 내부에 있었는데, 이도 마찬가지로 key로 분리되는 hook의 특성과 어울리지 않는다고 판단해서 지웠습니다. 
- clear가 필요하다면 `window.localStorage.clear`를 쓰는게 좋겠다고 판단했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 
